### PR TITLE
Add tramplable bush object to multigrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The EMPO framework so far provides:
 #### MultiGrid (`vendor/multigrid/`)
 Extended multi-agent gridworld environment with:
 - State management and transition probability computation
-- New object types: Rock, Block, UnsteadyGround, MagicWall
+- New object types: Rock, Block, Bush, UnsteadyGround, MagicWall
 - Map-based environment specification
 - Agent-specific capabilities (can_push_rocks, can_enter_magic_walls)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -261,6 +261,7 @@ The vendored `gym_multigrid` in `vendor/multigrid/` extends the original with:
 |------|-------------|
 | `Block` | Pushable by any agent |
 | `Rock` | Pushable only by authorized agents (based on `can_push_rocks`) |
+| `Bush` | Non-overlappable obstacle until a robot-like agent tramples it; then the cell becomes empty for all agents |
 
 #### Terrain Objects
 
@@ -328,6 +329,7 @@ class MyEnv(MultiGridEnv):
 | `Ae` | Grey agent |
 | `Ro` | Rock |
 | `Bl` | Block |
+| `Bu` | Bush |
 | `La` | Lava |
 | `Un` | Unsteady ground |
 | `Sw` | Switch |

--- a/docs/BATCHED_COMPUTATION.md
+++ b/docs/BATCHED_COMPUTATION.md
@@ -140,7 +140,7 @@ See `constants.py` for the exact bit masks and shifts used:
 
 | Bits | Field | Values |
 |------|-------|--------|
-| 0-4 | object_type | 0-28 = standard types (see `OBJECT_TYPE_TO_CHANNEL`), 30 = door, 31 = key |
+| 0-4 | object_type | 0-29 = standard types (see `OBJECT_TYPE_TO_CHANNEL`), 30 = door, 31 = key |
 | 5-7 | object_color | 0-6 = color index (for doors/keys) |
 | 8-9 | object_state | 0-3 = door state (none/open/closed/locked) |
 | 10-12 | agent_color | 0-6 = agent color, 7 = no agent |

--- a/docs/ENCODER_ARCHITECTURE.md
+++ b/docs/ENCODER_ARCHITECTURE.md
@@ -263,10 +263,10 @@ Total Channels = num_object_type_channels + 3 + num_colors
                        |                   |       |
                        |                   |       +-- Per-color agent channels (7 standard colors)
                        |                   +-- "Other objects" channels (3: overlappable, immobile, mobile)
-                       +-- Object type channels (29 total, see OBJECT_TYPE_TO_CHANNEL)
+                       +-- Object type channels (30 total, see OBJECT_TYPE_TO_CHANNEL)
 ```
 
-### Object Type Channels (29 channels)
+### Object Type Channels (30 channels)
 
 | Channel Range | Object Type | Value Encoding |
 |---------------|-------------|----------------|
@@ -288,7 +288,7 @@ For off-policy learning, the full grid tensor (39 channels × H × W = 7644 byte
 
 | Bits | Field | Description |
 |------|-------|-------------|
-| 0-4 | object_type | 0-28 standard types (see `OBJECT_TYPE_TO_CHANNEL`), 30=door, 31=key |
+| 0-4 | object_type | 0-29 standard types (see `OBJECT_TYPE_TO_CHANNEL`), 30=door, 31=key |
 | 5-7 | object_color | 0-6 color index (for doors/keys) |
 | 8-9 | object_state | 0-3 door state (none/open/closed/locked) |
 | 10-12 | agent_color | 0-6 agent color, 7=no agent |

--- a/examples/phase2/phase2_robot_policy_demo.py
+++ b/examples/phase2/phase2_robot_policy_demo.py
@@ -140,8 +140,11 @@ class GenericGoalGenerator(PossibleGoalGenerator):
         for x in range(self.env.width):
             for y in range(self.env.height):
                 cell = grid.get(x, y)
-                # Cell is walkable if empty or contains only an agent
+                # Cell is a possible goal if empty, overlappable, occupied by
+                # an agent, or a bush that can become empty after trampling.
                 if cell is None:
+                    walkable.append((x, y))
+                elif getattr(cell, 'type', None) == 'bush':
                     walkable.append((x, y))
                 elif hasattr(cell, 'can_overlap') and cell.can_overlap():
                     walkable.append((x, y))

--- a/multigrid_worlds/README.md
+++ b/multigrid_worlds/README.md
@@ -48,6 +48,7 @@ Maps use two-character codes separated by spaces. The `|` syntax in YAML preserv
 - `Ar`, `Ag`, `Ab`, `Ap`, `Ay`, `Ae` - Agent (red, green, blue, purple, yellow, grey)
 - `Bl` - Block (pushable)
 - `Ro` - Rock (pushable by certain agents)
+- `Bu` - Bush (blocks humans until trampled by a robot)
 - `La` - Lava
 - `Un` - Unsteady ground
 - `Gr`, `Gg`, `Gb`, etc. - Goal (with color)

--- a/multigrid_worlds/basic/all_object_types.yaml
+++ b/multigrid_worlds/basic/all_object_types.yaml
@@ -1,7 +1,7 @@
 # Reference grid showcasing all object types
 metadata:
   name: "All Object Types"
-  description: "10x7 grid showcasing all object types available in the multigrid environment: blocks, rocks, lava, switches, unsteady ground, goals, keys, balls, boxes, and doors."
+  description: "10x7 grid showcasing all object types available in the multigrid environment: blocks, rocks, bushes, lava, switches, unsteady ground, goals, keys, balls, boxes, and doors."
   author: "EMPO Framework"
   version: "1.0.0"
   created: "2025-01-01T00:00:00Z"
@@ -10,7 +10,7 @@ metadata:
 
 map: |
   We We We We We We We We We We
-  We Bl Ro La Sw Un .. .. .. We
+  We Bl Ro Bu La Sw Un .. .. We
   We Gr Kr Br Xr .. .. .. .. We
   We Lr Cr Or .. .. .. .. .. We
   We Mn Ms Mw Me .. .. .. .. We

--- a/multigrid_worlds/bush/corridor_bush.yaml
+++ b/multigrid_worlds/bush/corridor_bush.yaml
@@ -12,6 +12,7 @@ max_steps: 20
 orientations: ["s", "n", "n"]
 can_push_rocks: "e"
 partial_obs: false
+trample_probability: 0.7
 
 possible_goals:
   - "2,1"

--- a/multigrid_worlds/bush/corridor_bush.yaml
+++ b/multigrid_worlds/bush/corridor_bush.yaml
@@ -1,0 +1,27 @@
+
+map: |
+  We We We We We
+  We We Ay We We
+  We We Bu We We
+  We Bu Ae Bu We
+  We Bu Bu Bu We
+  We Bu Ay Bu We
+  We We We We We
+
+max_steps: 20
+orientations: ["s", "n", "n"]
+can_push_rocks: "e"
+partial_obs: false
+
+possible_goals:
+  - "2,1"
+  - "2,2"
+  - "2,3"
+  - "2,4"
+  - "2,5"
+  - "1,3"
+  - "3,3"
+  - "1,4"
+  - "3,4"
+  - "1,5"
+  - "3,5"

--- a/multigrid_worlds/bush/corridor_bush.yaml
+++ b/multigrid_worlds/bush/corridor_bush.yaml
@@ -12,7 +12,7 @@ max_steps: 20
 orientations: ["s", "n", "n"]
 can_push_rocks: "e"
 partial_obs: false
-trample_probability: 0.7
+enter_bush_success_prob: 0.7
 
 possible_goals:
   - "2,1"

--- a/src/empo/__init__.py
+++ b/src/empo/__init__.py
@@ -27,7 +27,7 @@ This package works with the vendored MultiGrid environment in `vendor/multigrid/
 which has been extended with:
 - Explicit state management (get_state, set_state)
 - Transition probability computation
-- New object types: Block, Rock, UnsteadyGround, MagicWall
+- New object types: Block, Rock, Bush, UnsteadyGround, MagicWall
 - Map-based environment specification
 
 Example usage:

--- a/src/empo/hierarchical/cell_partition.py
+++ b/src/empo/hierarchical/cell_partition.py
@@ -185,7 +185,7 @@ class CellPartition:
         width: int,
         height: int,
         *,
-        excluded_types: FrozenSet[str] = frozenset({'wall', 'lava'}),
+        excluded_types: FrozenSet[str] = frozenset({'wall', 'lava', 'bush'}),
         seed: Optional[int] = None,
     ) -> 'CellPartition':
         """Create a partition from a grid with ``.get(x, y)`` access.
@@ -200,7 +200,7 @@ class CellPartition:
             width: Grid width.
             height: Grid height.
             excluded_types: Cell types to exclude from the partition.
-                Defaults to ``{'wall', 'lava'}``.
+                Defaults to ``{'wall', 'lava', 'bush'}``.
             seed: Random seed for tie-breaking.
 
         Returns:

--- a/src/empo/human_policy_prior.py
+++ b/src/empo/human_policy_prior.py
@@ -653,7 +653,7 @@ class HeuristicPotentialPolicy(HumanPolicyPrior):
         cell_type = getattr(cell, 'type', None)
         
         # Impassable obstacles (cannot be moved through even with pushing)
-        if cell_type in ('wall', 'magicwall', 'lava', 'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton'):
+        if cell_type in ('wall', 'magicwall', 'lava', 'bush', 'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton'):
             return False
         
         # Doors: closed/locked doors are obstacles (for simplicity)
@@ -867,7 +867,7 @@ class HeuristicPotentialPolicy(HumanPolicyPrior):
             if cell is not None:
                 cell_type = getattr(cell, 'type', None)
                 # Can't drop on walls, doors, keys, balls, boxes, etc.
-                if cell_type in ('wall', 'door', 'key', 'ball', 'box', 'block', 'rock', 'lava', 'magicwall'):
+                if cell_type in ('wall', 'door', 'key', 'ball', 'box', 'block', 'rock', 'lava', 'magicwall', 'bush'):
                     continue
             
             # Calculate potential for this cell

--- a/src/empo/learning_based/multigrid/constants.py
+++ b/src/empo/learning_based/multigrid/constants.py
@@ -40,26 +40,27 @@ OBJECT_TYPE_TO_CHANNEL = {
     'pauseswitch': 11,
     'disablingswitch': 12,
     'controlbutton': 13,
+    'bush': 14,
 }
-NUM_BASE_OBJECT_CHANNELS = 14
+NUM_BASE_OBJECT_CHANNELS = 15
 
 # Per-color door channels: value encodes state (1=open, 2=closed, 3=locked)
-DOOR_CHANNEL_START = NUM_BASE_OBJECT_CHANNELS  # 14
+DOOR_CHANNEL_START = NUM_BASE_OBJECT_CHANNELS  # 15
 DOOR_STATE_NONE = 0
 DOOR_STATE_OPEN = 1
 DOOR_STATE_CLOSED = 2
 DOOR_STATE_LOCKED = 3
 
 # Per-color key channels: value = 1 if present
-KEY_CHANNEL_START = DOOR_CHANNEL_START + NUM_STANDARD_COLORS  # 21
+KEY_CHANNEL_START = DOOR_CHANNEL_START + NUM_STANDARD_COLORS  # 22
 
 # Magic wall channel: value encodes magic_side (1-5) or inactive (6)
-MAGICWALL_CHANNEL = KEY_CHANNEL_START + NUM_STANDARD_COLORS  # 28
+MAGICWALL_CHANNEL = KEY_CHANNEL_START + NUM_STANDARD_COLORS  # 29
 MAGICWALL_STATE_NONE = 0
 MAGICWALL_STATE_ACTIVE_BASE = 1  # Add magic_side (0-4) to get 1-5
 MAGICWALL_STATE_INACTIVE = 6
 
-NUM_OBJECT_TYPE_CHANNELS = MAGICWALL_CHANNEL + 1  # 29
+NUM_OBJECT_TYPE_CHANNELS = MAGICWALL_CHANNEL + 1  # 30
 
 # =============================================================================
 # OBJECT CATEGORIES
@@ -70,7 +71,7 @@ OVERLAPPABLE_OBJECTS = {
     'unsteadyground', 'objectgoal'
 }
 NON_OVERLAPPABLE_IMMOBILE_OBJECTS = {
-    'wall', 'magicwall', 'lava', 'door', 'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton'
+    'wall', 'magicwall', 'lava', 'door', 'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton', 'bush'
 }
 NON_OVERLAPPABLE_MOBILE_OBJECTS = {'block', 'rock'}
 
@@ -141,7 +142,7 @@ SMALL_ACTION_ENCODING = {
 # =============================================================================
 # 
 # Each cell is encoded as a single int32 with the following bit layout:
-# Bits 0-4 (5 bits): object_type (0-31, maps to OBJECT_TYPE_TO_CHANNEL or special values)
+# Bits 0-4 (5 bits): object_type (0-29 standard channels, 30/31 special values)
 # Bits 5-7 (3 bits): object_color (0-7, maps to COLOR_TO_IDX)
 # Bits 8-9 (2 bits): object_state (0-3, for doors: 0=none, 1=open, 2=closed, 3=locked)
 # Bits 10-12 (3 bits): agent_color (0-7, 7 means no agent)

--- a/src/empo/learning_based/multigrid/path_distance.py
+++ b/src/empo/learning_based/multigrid/path_distance.py
@@ -27,6 +27,7 @@ DEFAULT_PASSING_COSTS = {
     'rock': 50,
     'wall': float('inf'),
     'magicwall': float('inf'),
+    'bush': float('inf'),
     'lava': float('inf'),  # Deadly - impassable
     'unsteadyground': 2,
     'unknown': 2,
@@ -99,7 +100,7 @@ class PathDistanceCalculator:
                 cell = world_model.grid.get(x, y)
                 if cell is not None:
                     cell_type = getattr(cell, 'type', None)
-                    if cell_type in ('wall', 'magicwall', 'lava'):
+                    if cell_type in ('wall', 'magicwall', 'lava', 'bush'):
                         wall_grid[y, x] = True
         
         return wall_grid
@@ -213,7 +214,7 @@ class PathDistanceCalculator:
                         cell = world_model.grid.get(x, y)
                         if cell is not None:
                             cell_type = getattr(cell, 'type', None)
-                            if cell_type in ('wall', 'magicwall', 'lava'):
+                            if cell_type in ('wall', 'magicwall', 'lava', 'bush'):
                                 obstacles.add((x, y))
             dist = self.get_distance(source, target, obstacles)
             return dist  # Simple step count
@@ -287,6 +288,9 @@ class PathDistanceCalculator:
         
         elif cell_type in ('wall', 'magicwall'):
             return self.passing_costs.get('wall', float('inf'))
+
+        elif cell_type == 'bush':
+            return self.passing_costs.get('bush', float('inf'))
         
         elif cell_type == 'lava':
             return self.passing_costs.get('lava', float('inf'))
@@ -594,7 +598,7 @@ class PathDistanceCalculator:
                 if cell is not None:
                     cell_type = getattr(cell, 'type', None)
                     # Check if cell blocks movement
-                    if cell_type in ('wall', 'lava'):
+                    if cell_type in ('wall', 'lava', 'bush'):
                         obstacles.add((x, y))
                     elif cell_type == 'door':
                         # Locked/closed doors are obstacles

--- a/src/empo/learning_based/multigrid/state_encoder.py
+++ b/src/empo/learning_based/multigrid/state_encoder.py
@@ -641,6 +641,15 @@ class MultiGridStateEncoder(BaseStateEncoder):
                     magic_state = MAGICWALL_STATE_INACTIVE
                 current = (current & ~COMPRESSED_GRID_MAGIC_MASK) | (magic_state << COMPRESSED_GRID_MAGIC_SHIFT)
                 compressed[y, x] = current
+
+            elif obj_type == 'bush':
+                trampled = obj_data[3] if len(obj_data) > 3 else False
+                current = int(compressed[y, x].item())
+                current = current & ~COMPRESSED_GRID_OBJECT_TYPE_MASK
+                current = current & ~COMPRESSED_GRID_OTHER_MASK
+                if not trampled:
+                    current |= OBJECT_TYPE_TO_CHANNEL.get('bush', 0)
+                compressed[y, x] = current
         
         # Third pass: encode mobile objects (overwrite object type at their positions)
         for obj_data in mobile_objects:
@@ -892,6 +901,16 @@ class MultiGridStateEncoder(BaseStateEncoder):
                         self._encode_other_object(cell, cell_type, x, y, grid_tensor)
         
         # Encode mobile objects
+        for obj_data in mutable_objects:
+            if obj_data[0] != 'bush':
+                continue
+            x, y = obj_data[1], obj_data[2]
+            trampled = obj_data[3] if len(obj_data) > 3 else False
+            if 0 <= x < W and 0 <= y < H:
+                bush_channel = OBJECT_TYPE_TO_CHANNEL.get('bush')
+                if bush_channel is not None:
+                    grid_tensor[0, bush_channel, y, x] = 0.0 if trampled else 1.0
+
         if mobile_objects:
             for obj_data in mobile_objects:
                 obj_type, obj_x, obj_y = obj_data[0], obj_data[1], obj_data[2]

--- a/src/empo/possible_goal.py
+++ b/src/empo/possible_goal.py
@@ -557,7 +557,7 @@ class TabularGoalSampler(PossibleGoalSampler):
         # Find all walkable cells (not containing immovable non-overlappable objects)
         # Agents can never stand on these cell types:
         non_walkable_types = {
-            'wall', 'lava', 'magicwall',
+            'wall', 'lava', 'magicwall', 'bush',
             'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton',
         }
         uncovered = []
@@ -689,7 +689,7 @@ class TabularGoalGenerator(PossibleGoalGenerator):
         # Find all walkable cells (not containing immovable non-overlappable objects)
         # Agents can never stand on these cell types:
         non_walkable_types = {
-            'wall', 'lava', 'magicwall',
+            'wall', 'lava', 'magicwall', 'bush',
             'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton',
         }
         uncovered = []

--- a/src/empo/possible_goal.py
+++ b/src/empo/possible_goal.py
@@ -557,7 +557,7 @@ class TabularGoalSampler(PossibleGoalSampler):
         # Find all walkable cells (not containing immovable non-overlappable objects)
         # Agents can never stand on these cell types.
         # Note: 'bush' is intentionally excluded — all agents can attempt to enter a bush
-        # (humans with trample_probability, robots with certainty), so bush cells are
+        # (humans with enter_bush_success_prob, robots with certainty), so bush cells are
         # potentially occupiable and must be covered by goals.
         non_walkable_types = {
             'wall', 'lava', 'magicwall',
@@ -692,7 +692,7 @@ class TabularGoalGenerator(PossibleGoalGenerator):
         # Find all walkable cells (not containing immovable non-overlappable objects)
         # Agents can never stand on these cell types.
         # Note: 'bush' is intentionally excluded — all agents can attempt to enter a bush
-        # (humans with trample_probability, robots with certainty), so bush cells are
+        # (humans with enter_bush_success_prob, robots with certainty), so bush cells are
         # potentially occupiable and must be covered by goals.
         non_walkable_types = {
             'wall', 'lava', 'magicwall',

--- a/src/empo/possible_goal.py
+++ b/src/empo/possible_goal.py
@@ -555,9 +555,12 @@ class TabularGoalSampler(PossibleGoalSampler):
                 covered_cells.add(goal.target_pos)
         
         # Find all walkable cells (not containing immovable non-overlappable objects)
-        # Agents can never stand on these cell types:
+        # Agents can never stand on these cell types.
+        # Note: 'bush' is intentionally excluded — all agents can attempt to enter a bush
+        # (humans with trample_probability, robots with certainty), so bush cells are
+        # potentially occupiable and must be covered by goals.
         non_walkable_types = {
-            'wall', 'lava', 'magicwall', 'bush',
+            'wall', 'lava', 'magicwall',
             'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton',
         }
         uncovered = []
@@ -687,9 +690,12 @@ class TabularGoalGenerator(PossibleGoalGenerator):
                 covered_cells.add(goal.target_pos)
         
         # Find all walkable cells (not containing immovable non-overlappable objects)
-        # Agents can never stand on these cell types:
+        # Agents can never stand on these cell types.
+        # Note: 'bush' is intentionally excluded — all agents can attempt to enter a bush
+        # (humans with trample_probability, robots with certainty), so bush cells are
+        # potentially occupiable and must be covered by goals.
         non_walkable_types = {
-            'wall', 'lava', 'magicwall', 'bush',
+            'wall', 'lava', 'magicwall',
             'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton',
         }
         uncovered = []

--- a/tests/test_bush.py
+++ b/tests/test_bush.py
@@ -17,7 +17,11 @@ from gym_multigrid.multigrid import Agent, Bush, Grid, MultiGridEnv, Wall, World
 
 
 class BushTestEnv(MultiGridEnv):
-    """Small corridor with a bush between an agent and open floor."""
+    """Small corridor with a bush at (2,2), one step ahead of the agent.
+
+    Use ``robot=True`` (default) for a grey robot that always tramples; use
+    ``robot=False`` for a yellow human whose success depends on ``trample_probability``.
+    """
 
     def __init__(self, robot=True, trample_probability=1.0):
         agent = Agent(

--- a/tests/test_bush.py
+++ b/tests/test_bush.py
@@ -5,12 +5,12 @@ Semantics
 ---------
 * **Robots** (can_push_rocks / can_enter_magic_walls / grey) always **trample** the
   bush with certainty: the bush is permanently removed from the grid and the cell
-  becomes empty.  ``trample_probability`` does not affect robots.
+  becomes empty.  ``enter_bush_success_prob`` does not affect robots.
 
 * **Human** agents (all others) **enter** the bush without trampling it.  The agent
   occupies the cell alongside the bush (like terrain); when the agent leaves the
   cell the bush is restored.  Success is stochastic with probability
-  ``trample_probability`` (default 1.0, i.e. always succeeds by default).
+  ``enter_bush_success_prob`` (default 1.0, i.e. always succeeds by default).
 
 Key invariants tested here
 --------------------------
@@ -19,9 +19,9 @@ Key invariants tested here
 * When a human leaves the bush cell -> bush is still there (restored to grid).
 * ``can_forward()`` returns True for both agent types when facing a bush.
 * ``transition_probabilities()`` returns a single outcome for robots and for humans
-  with ``trample_probability==1.0``.
+  with ``enter_bush_success_prob==1.0``.
 * ``transition_probabilities()`` returns two outcomes for humans with
-  ``trample_probability<1.0``: succeed (agent on bush, bush intact) and fail (agent
+  ``enter_bush_success_prob<1.0``: succeed (agent on bush, bush intact) and fail (agent
   stays, bush intact).
 * ``set_state()`` correctly restores a state where a human is on a bush.
 """
@@ -36,10 +36,10 @@ class BushTestEnv(MultiGridEnv):
 
     Use ``robot=True`` (default) for a grey robot that always tramples;
     use ``robot=False`` for a yellow human whose success depends on
-    ``trample_probability``.
+    ``enter_bush_success_prob``.
     """
 
-    def __init__(self, robot=True, trample_probability=1.0):
+    def __init__(self, robot=True, enter_bush_success_prob=1.0):
         agent = Agent(
             World,
             5 if robot else 4,
@@ -53,7 +53,7 @@ class BushTestEnv(MultiGridEnv):
             agents=[agent],
             partial_obs=False,
             objects_set=World,
-            trample_probability=trample_probability,
+            enter_bush_success_prob=enter_bush_success_prob,
         )
 
     def _gen_grid(self, width, height):
@@ -68,7 +68,7 @@ class BushTestEnv(MultiGridEnv):
         self.agents[0].pos = np.array([1, 2])
         self.agents[0].dir = 0
         self.grid.set(1, 2, self.agents[0])
-        self.grid.set(2, 2, Bush(World, trample_probability=self.trample_probability))
+        self.grid.set(2, 2, Bush(World, enter_bush_success_prob=self.enter_bush_success_prob))
 
 
 class BushHumanPassageEnv(MultiGridEnv):
@@ -116,14 +116,14 @@ def test_bush_creation():
     assert bush.type == 'bush'
     assert bush.color == 'green'
     assert bush.trampled is False
-    assert bush.trample_probability == 1.0
+    assert bush.enter_bush_success_prob == 1.0
     assert not bush.can_overlap()
     assert not bush.can_pickup()
 
 
 def test_bush_creation_with_probability():
-    bush = Bush(World, trample_probability=0.5)
-    assert bush.trample_probability == 0.5
+    bush = Bush(World, enter_bush_success_prob=0.5)
+    assert bush.enter_bush_success_prob == 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -159,9 +159,9 @@ def test_robot_tramples_bush_and_state_tracks_it():
     assert ('bush', 2, 2, True) in env.get_state()[3]
 
 
-def test_robot_always_tramples_regardless_of_trample_probability():
-    """Robots trample with certainty even when trample_probability is set low."""
-    env = BushTestEnv(robot=True, trample_probability=0.1)
+def test_robot_always_tramples_regardless_of_enter_bush_success_prob():
+    """Robots trample with certainty even when enter_bush_success_prob is set low."""
+    env = BushTestEnv(robot=True, enter_bush_success_prob=0.1)
     env.reset()
 
     obs, rewards, done, info = env.step([3])
@@ -171,8 +171,8 @@ def test_robot_always_tramples_regardless_of_trample_probability():
 
 
 def test_robot_transition_is_always_deterministic_single_outcome():
-    """Robots always produce a single (p=1.0) outcome regardless of trample_probability."""
-    env = BushTestEnv(robot=True, trample_probability=0.3)
+    """Robots always produce a single (p=1.0) outcome regardless of enter_bush_success_prob."""
+    env = BushTestEnv(robot=True, enter_bush_success_prob=0.3)
     env.reset()
 
     state = env.get_state()
@@ -218,8 +218,8 @@ def test_human_can_pass_after_robot_tramples_bush():
 # ---------------------------------------------------------------------------
 
 def test_human_enters_bush_with_certainty_when_probability_is_1():
-    """With trample_probability==1.0 a human always enters, but the bush stays."""
-    env = BushTestEnv(robot=False, trample_probability=1.0)
+    """With enter_bush_success_prob==1.0 a human always enters, but the bush stays."""
+    env = BushTestEnv(robot=False, enter_bush_success_prob=1.0)
     env.reset()
 
     obs, rewards, done, info = env.step([3])
@@ -236,8 +236,8 @@ def test_human_enters_bush_with_certainty_when_probability_is_1():
 
 
 def test_human_cannot_enter_bush_when_probability_is_zero():
-    """When trample_probability==0.0 a human can never enter the bush."""
-    env = BushTestEnv(robot=False, trample_probability=0.0)
+    """When enter_bush_success_prob==0.0 a human can never enter the bush."""
+    env = BushTestEnv(robot=False, enter_bush_success_prob=0.0)
     env.reset()
 
     obs, rewards, done, info = env.step([3])
@@ -251,7 +251,7 @@ def test_human_cannot_enter_bush_when_probability_is_zero():
 
 def test_human_exits_bush_and_bush_is_restored():
     """After a human enters a bush and then leaves, the bush is still there."""
-    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env = BushTestEnv(robot=False, enter_bush_success_prob=1.0)
     env.reset()
 
     env.step([3])  # Human enters bush at (2,2)
@@ -269,7 +269,7 @@ def test_human_exits_bush_and_bush_is_restored():
 
 def test_human_state_after_entering_bush():
     """get_state() reports the bush as untrampled (False) when a human is on it."""
-    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env = BushTestEnv(robot=False, enter_bush_success_prob=1.0)
     env.reset()
 
     env.step([3])
@@ -283,7 +283,7 @@ def test_human_state_after_entering_bush():
 
 def test_set_state_with_human_on_bush():
     """set_state() correctly restores a state where a human is on a bush."""
-    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env = BushTestEnv(robot=False, enter_bush_success_prob=1.0)
     env.reset()
 
     env.step([3])  # Human enters bush
@@ -309,8 +309,8 @@ def test_set_state_with_human_on_bush():
 # ---------------------------------------------------------------------------
 
 def test_human_probabilistic_bush_transition_probabilities():
-    """For humans with trample_probability < 1, transition_probabilities returns 2 outcomes."""
-    env = BushTestEnv(robot=False, trample_probability=0.6)
+    """For humans with enter_bush_success_prob < 1, transition_probabilities returns 2 outcomes."""
+    env = BushTestEnv(robot=False, enter_bush_success_prob=0.6)
     env.reset()
 
     state = env.get_state()
@@ -325,7 +325,7 @@ def test_human_probabilistic_bush_transition_probabilities():
 
 def test_human_probabilistic_bush_succeed_outcome_moves_agent_bush_intact():
     """When human entry succeeds, agent moves to bush cell and bush remains (untrampled)."""
-    env = BushTestEnv(robot=False, trample_probability=0.6)
+    env = BushTestEnv(robot=False, enter_bush_success_prob=0.6)
     env.reset()
 
     state = env.get_state()
@@ -346,7 +346,7 @@ def test_human_probabilistic_bush_succeed_outcome_moves_agent_bush_intact():
 
 def test_human_probabilistic_bush_fail_outcome_keeps_agent():
     """When human entry fails, agent stays put and bush remains."""
-    env = BushTestEnv(robot=False, trample_probability=0.6)
+    env = BushTestEnv(robot=False, enter_bush_success_prob=0.6)
     env.reset()
 
     state = env.get_state()
@@ -366,8 +366,8 @@ def test_human_probabilistic_bush_fail_outcome_keeps_agent():
 
 
 def test_human_deterministic_bush_single_outcome():
-    """With trample_probability=1.0, a human produces a single deterministic outcome."""
-    env = BushTestEnv(robot=False, trample_probability=1.0)
+    """With enter_bush_success_prob=1.0, a human produces a single deterministic outcome."""
+    env = BushTestEnv(robot=False, enter_bush_success_prob=1.0)
     env.reset()
 
     state = env.get_state()
@@ -380,7 +380,7 @@ def test_human_deterministic_bush_single_outcome():
 
 def test_step_consistent_with_transition_probabilities_for_human_probabilistic_bush():
     """step() and transition_probabilities() produce consistent distributions for humans."""
-    env = BushTestEnv(robot=False, trample_probability=0.5)
+    env = BushTestEnv(robot=False, enter_bush_success_prob=0.5)
     env.reset()
 
     state = env.get_state()
@@ -402,10 +402,10 @@ def test_step_consistent_with_transition_probabilities_for_human_probabilistic_b
 # ---------------------------------------------------------------------------
 
 def test_probabilistic_bush_via_config():
-    """trample_probability from MultiGridEnv constructor applies to map-parsed bushes."""
+    """enter_bush_success_prob from MultiGridEnv constructor applies to map-parsed bushes."""
     env = MultiGridEnv(
         map="We We We We\nWe Ae Bu We\nWe We We We",
-        trample_probability=0.5,
+        enter_bush_success_prob=0.5,
         objects_set=World,
         partial_obs=False,
     )
@@ -420,4 +420,4 @@ def test_probabilistic_bush_via_config():
         if found_bush:
             break
     assert found_bush is not None, "No bush found in the grid"
-    assert found_bush.trample_probability == 0.5
+    assert found_bush.enter_bush_success_prob == 0.5

--- a/tests/test_bush.py
+++ b/tests/test_bush.py
@@ -1,14 +1,29 @@
 """
-Tests for robot-tramplable bushes.
+Tests for bush semantics.
 
-Semantics after refactor
-------------------------
-* All agents can attempt to walk through a bush via the forward action.
-* Robot-like agents (can_push_rocks or can_enter_magic_walls or grey) always
-  succeed and trample the bush with certainty (probability 1.0), regardless of
-  the bush's ``trample_probability`` setting.
-* Human agents succeed with probability ``trample_probability`` (default 1.0).
-  When they succeed the bush is trampled and removed just like for a robot.
+Semantics
+---------
+* **Robots** (can_push_rocks / can_enter_magic_walls / grey) always **trample** the
+  bush with certainty: the bush is permanently removed from the grid and the cell
+  becomes empty.  ``trample_probability`` does not affect robots.
+
+* **Human** agents (all others) **enter** the bush without trampling it.  The agent
+  occupies the cell alongside the bush (like terrain); when the agent leaves the
+  cell the bush is restored.  Success is stochastic with probability
+  ``trample_probability`` (default 1.0, i.e. always succeeds by default).
+
+Key invariants tested here
+--------------------------
+* After a robot enters a bush  -> bush is gone (trampled=True).
+* After a human enters a bush  -> bush is still there (trampled=False), agent at (2,2).
+* When a human leaves the bush cell -> bush is still there (restored to grid).
+* ``can_forward()`` returns True for both agent types when facing a bush.
+* ``transition_probabilities()`` returns a single outcome for robots and for humans
+  with ``trample_probability==1.0``.
+* ``transition_probabilities()`` returns two outcomes for humans with
+  ``trample_probability<1.0``: succeed (agent on bush, bush intact) and fail (agent
+  stays, bush intact).
+* ``set_state()`` correctly restores a state where a human is on a bush.
 """
 
 import numpy as np
@@ -17,10 +32,11 @@ from gym_multigrid.multigrid import Agent, Bush, Grid, MultiGridEnv, Wall, World
 
 
 class BushTestEnv(MultiGridEnv):
-    """Small corridor with a bush at (2,2), one step ahead of the agent.
+    """Small 5x5 corridor: agent at (1,2) facing right, bush at (2,2).
 
-    Use ``robot=True`` (default) for a grey robot that always tramples; use
-    ``robot=False`` for a yellow human whose success depends on ``trample_probability``.
+    Use ``robot=True`` (default) for a grey robot that always tramples;
+    use ``robot=False`` for a yellow human whose success depends on
+    ``trample_probability``.
     """
 
     def __init__(self, robot=True, trample_probability=1.0):
@@ -128,11 +144,11 @@ def test_human_can_forward_into_bush():
 
 
 # ---------------------------------------------------------------------------
-# Deterministic trampling (trample_probability == 1.0)
+# Robot trampling: bush is permanently removed
 # ---------------------------------------------------------------------------
 
 def test_robot_tramples_bush_and_state_tracks_it():
-    """Robots always trample with certainty."""
+    """Robots always trample with certainty; bush is removed from grid."""
     env = BushTestEnv(robot=True)
     env.reset()
 
@@ -143,54 +159,30 @@ def test_robot_tramples_bush_and_state_tracks_it():
     assert ('bush', 2, 2, True) in env.get_state()[3]
 
 
-def test_human_enters_bush_with_certainty_when_probability_is_1():
-    """When trample_probability==1.0 a human tramples the bush just like a robot."""
-    env = BushTestEnv(robot=False, trample_probability=1.0)
-    env.reset()
-
-    obs, rewards, done, info = env.step([3])
-
-    assert np.array_equal(env.agents[0].pos, [2, 2])
-    assert env.grid.get(2, 2) is env.agents[0]
-    assert ('bush', 2, 2, True) in env.get_state()[3]
-
-
-def test_human_cannot_enter_bush_when_probability_is_zero():
-    """When trample_probability==0.0 a human can never enter the bush."""
-    env = BushTestEnv(robot=False, trample_probability=0.0)
-    env.reset()
-
-    obs, rewards, done, info = env.step([3])
-
-    assert np.array_equal(env.agents[0].pos, [1, 2])
-    bush = env.grid.get(2, 2)
-    assert bush is not None
-    assert bush.type == 'bush'
-    assert bush.trampled is False
-
-
 def test_robot_always_tramples_regardless_of_trample_probability():
     """Robots trample with certainty even when trample_probability is set low."""
     env = BushTestEnv(robot=True, trample_probability=0.1)
     env.reset()
 
-    # step() should always succeed for a robot
     obs, rewards, done, info = env.step([3])
 
     assert np.array_equal(env.agents[0].pos, [2, 2])
     assert ('bush', 2, 2, True) in env.get_state()[3]
 
 
-def test_human_can_pass_after_robot_tramples_bush():
-    env = BushHumanPassageEnv()
+def test_robot_transition_is_always_deterministic_single_outcome():
+    """Robots always produce a single (p=1.0) outcome regardless of trample_probability."""
+    env = BushTestEnv(robot=True, trample_probability=0.3)
     env.reset()
 
-    env.step([3, 0])  # Robot tramples bush, human waits.
-    env.step([3, 3])  # Robot leaves; human's target was occupied at step start.
-    env.step([0, 3])  # Human can now enter the cleared cell.
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
 
-    assert np.array_equal(env.agents[1].pos, [2, 2])
-    assert ('bush', 2, 2, True) in env.get_state()[3]
+    assert outcomes is not None
+    assert len(outcomes) == 1, (
+        f"Expected 1 deterministic outcome for robot, got {len(outcomes)}"
+    )
+    assert abs(outcomes[0][0] - 1.0) < 1e-9
 
 
 def test_set_state_restores_untrampled_bush():
@@ -208,24 +200,113 @@ def test_set_state_restores_untrampled_bush():
     assert bush.trampled is False
 
 
-# ---------------------------------------------------------------------------
-# Stochastic trampling — now applies to HUMAN agents
-# ---------------------------------------------------------------------------
-
-def test_robot_transition_is_always_deterministic_single_outcome():
-    """Robots always produce a single (p=1.0) outcome regardless of trample_probability."""
-    env = BushTestEnv(robot=True, trample_probability=0.3)
+def test_human_can_pass_after_robot_tramples_bush():
+    """After a robot tramples a bush, the cell is empty and a human can pass freely."""
+    env = BushHumanPassageEnv()
     env.reset()
 
+    env.step([3, 0])  # Robot tramples bush, human waits.
+    env.step([3, 3])  # Robot leaves; human's target was occupied at step start.
+    env.step([0, 3])  # Human can now enter the cleared cell.
+
+    assert np.array_equal(env.agents[1].pos, [2, 2])
+    assert ('bush', 2, 2, True) in env.get_state()[3]
+
+
+# ---------------------------------------------------------------------------
+# Human entry: bush stays intact
+# ---------------------------------------------------------------------------
+
+def test_human_enters_bush_with_certainty_when_probability_is_1():
+    """With trample_probability==1.0 a human always enters, but the bush stays."""
+    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env.reset()
+
+    obs, rewards, done, info = env.step([3])
+
+    # Agent moved to (2,2)
+    assert np.array_equal(env.agents[0].pos, [2, 2])
+    # Bush is still intact (untrampled) -- stored in terrain_grid
+    assert ('bush', 2, 2, False) in env.get_state()[3]
+    # Grid shows agent; bush is in terrain_grid
+    assert env.grid.get(2, 2) is env.agents[0]
+    terrain_cell = env.terrain_grid.get(2, 2)
+    assert terrain_cell is not None
+    assert terrain_cell.type == 'bush'
+
+
+def test_human_cannot_enter_bush_when_probability_is_zero():
+    """When trample_probability==0.0 a human can never enter the bush."""
+    env = BushTestEnv(robot=False, trample_probability=0.0)
+    env.reset()
+
+    obs, rewards, done, info = env.step([3])
+
+    assert np.array_equal(env.agents[0].pos, [1, 2])
+    bush = env.grid.get(2, 2)
+    assert bush is not None
+    assert bush.type == 'bush'
+    assert bush.trampled is False
+
+
+def test_human_exits_bush_and_bush_is_restored():
+    """After a human enters a bush and then leaves, the bush is still there."""
+    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env.reset()
+
+    env.step([3])  # Human enters bush at (2,2)
+    assert np.array_equal(env.agents[0].pos, [2, 2])
+
+    env.step([3])  # Human moves forward to (3,2), leaving the bush
+    assert np.array_equal(env.agents[0].pos, [3, 2])
+
+    # Bush should be restored at (2,2)
+    bush = env.grid.get(2, 2)
+    assert bush is not None
+    assert bush.type == 'bush'
+    assert bush.trampled is False
+
+
+def test_human_state_after_entering_bush():
+    """get_state() reports the bush as untrampled (False) when a human is on it."""
+    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env.reset()
+
+    env.step([3])
+
     state = env.get_state()
-    outcomes = env.transition_probabilities(state, [3])
+    agent_x, agent_y = state[1][0][0], state[1][0][1]
+    assert agent_x == 2 and agent_y == 2, "Agent should be on the bush cell"
+    # Bush should still be there, untrampled
+    assert ('bush', 2, 2, False) in state[3]
 
-    assert outcomes is not None
-    assert len(outcomes) == 1, (
-        f"Expected 1 deterministic outcome for robot, got {len(outcomes)}"
-    )
-    assert abs(outcomes[0][0] - 1.0) < 1e-9
 
+def test_set_state_with_human_on_bush():
+    """set_state() correctly restores a state where a human is on a bush."""
+    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env.reset()
+
+    env.step([3])  # Human enters bush
+    on_bush_state = env.get_state()
+
+    # Restore to a different state, then restore the on-bush state
+    env.step([0])  # Turn left (so internal state changes)
+    env.set_state(on_bush_state)
+
+    # Agent should be at (2,2), bush should be in terrain_grid
+    assert np.array_equal(env.agents[0].pos, [2, 2])
+    assert env.terrain_grid.get(2, 2) is not None
+    assert env.terrain_grid.get(2, 2).type == 'bush'
+    # Advance one step to make the human leave; bush should be restored to the grid
+    env.step([3])  # Move forward to (3,2)
+    bush = env.grid.get(2, 2)
+    assert bush is not None
+    assert bush.type == 'bush'
+
+
+# ---------------------------------------------------------------------------
+# Stochastic human entry
+# ---------------------------------------------------------------------------
 
 def test_human_probabilistic_bush_transition_probabilities():
     """For humans with trample_probability < 1, transition_probabilities returns 2 outcomes."""
@@ -242,8 +323,8 @@ def test_human_probabilistic_bush_transition_probabilities():
     assert abs(probs[1] - 0.4) < 1e-9, f"Expected fail prob 0.4, got {probs[1]}"
 
 
-def test_human_probabilistic_bush_succeed_outcome_moves_agent():
-    """When human trampling succeeds, agent moves into the cell and bush is trampled."""
+def test_human_probabilistic_bush_succeed_outcome_moves_agent_bush_intact():
+    """When human entry succeeds, agent moves to bush cell and bush remains (untrampled)."""
     env = BushTestEnv(robot=False, trample_probability=0.6)
     env.reset()
 
@@ -259,11 +340,12 @@ def test_human_probabilistic_bush_succeed_outcome_moves_agent():
 
     assert succeed_state is not None, "No succeed outcome found"
     assert abs(succeed_state[0] - 0.6) < 1e-9
-    assert ('bush', 2, 2, True) in succeed_state[1][3]
+    # Bush must still be UNTRAMPLED -- human entered, did not trample
+    assert ('bush', 2, 2, False) in succeed_state[1][3]
 
 
 def test_human_probabilistic_bush_fail_outcome_keeps_agent():
-    """When human trampling fails, agent stays put and bush remains."""
+    """When human entry fails, agent stays put and bush remains."""
     env = BushTestEnv(robot=False, trample_probability=0.6)
     env.reset()
 
@@ -279,6 +361,7 @@ def test_human_probabilistic_bush_fail_outcome_keeps_agent():
 
     assert fail_state is not None, "No fail outcome found"
     assert abs(fail_state[0] - 0.4) < 1e-9
+    # Bush is still untrampled
     assert ('bush', 2, 2, False) in fail_state[1][3]
 
 

--- a/tests/test_bush.py
+++ b/tests/test_bush.py
@@ -1,5 +1,14 @@
 """
 Tests for robot-tramplable bushes.
+
+Semantics after refactor
+------------------------
+* All agents can attempt to walk through a bush via the forward action.
+* Robot-like agents (can_push_rocks or can_enter_magic_walls or grey) always
+  succeed and trample the bush with certainty (probability 1.0), regardless of
+  the bush's ``trample_probability`` setting.
+* Human agents succeed with probability ``trample_probability`` (default 1.0).
+  When they succeed the bush is trampled and removed just like for a robot.
 """
 
 import numpy as np
@@ -8,7 +17,7 @@ from gym_multigrid.multigrid import Agent, Bush, Grid, MultiGridEnv, Wall, World
 
 
 class BushTestEnv(MultiGridEnv):
-    """Small corridor with a bush between a robot and open floor."""
+    """Small corridor with a bush between an agent and open floor."""
 
     def __init__(self, robot=True, trample_probability=1.0):
         agent = Agent(
@@ -77,6 +86,10 @@ class BushHumanPassageEnv(MultiGridEnv):
         self.grid.set(2, 2, Bush(World))
 
 
+# ---------------------------------------------------------------------------
+# Basic creation
+# ---------------------------------------------------------------------------
+
 def test_bush_creation():
     bush = Bush(World)
 
@@ -93,8 +106,54 @@ def test_bush_creation_with_probability():
     assert bush.trample_probability == 0.5
 
 
-def test_human_cannot_enter_untrampled_bush():
+# ---------------------------------------------------------------------------
+# can_forward: both robots and humans should report forward=True for a bush
+# ---------------------------------------------------------------------------
+
+def test_robot_can_forward_into_bush():
+    env = BushTestEnv(robot=True)
+    env.reset()
+    assert env.can_forward(env.get_state(), 0) is True
+
+
+def test_human_can_forward_into_bush():
+    """can_forward returns True for human agents facing a bush."""
     env = BushTestEnv(robot=False)
+    env.reset()
+    assert env.can_forward(env.get_state(), 0) is True
+
+
+# ---------------------------------------------------------------------------
+# Deterministic trampling (trample_probability == 1.0)
+# ---------------------------------------------------------------------------
+
+def test_robot_tramples_bush_and_state_tracks_it():
+    """Robots always trample with certainty."""
+    env = BushTestEnv(robot=True)
+    env.reset()
+
+    obs, rewards, done, info = env.step([3])
+
+    assert np.array_equal(env.agents[0].pos, [2, 2])
+    assert env.grid.get(2, 2) is env.agents[0]
+    assert ('bush', 2, 2, True) in env.get_state()[3]
+
+
+def test_human_enters_bush_with_certainty_when_probability_is_1():
+    """When trample_probability==1.0 a human tramples the bush just like a robot."""
+    env = BushTestEnv(robot=False, trample_probability=1.0)
+    env.reset()
+
+    obs, rewards, done, info = env.step([3])
+
+    assert np.array_equal(env.agents[0].pos, [2, 2])
+    assert env.grid.get(2, 2) is env.agents[0]
+    assert ('bush', 2, 2, True) in env.get_state()[3]
+
+
+def test_human_cannot_enter_bush_when_probability_is_zero():
+    """When trample_probability==0.0 a human can never enter the bush."""
+    env = BushTestEnv(robot=False, trample_probability=0.0)
     env.reset()
 
     obs, rewards, done, info = env.step([3])
@@ -106,15 +165,15 @@ def test_human_cannot_enter_untrampled_bush():
     assert bush.trampled is False
 
 
-def test_robot_tramples_bush_and_state_tracks_it():
-    env = BushTestEnv(robot=True)
+def test_robot_always_tramples_regardless_of_trample_probability():
+    """Robots trample with certainty even when trample_probability is set low."""
+    env = BushTestEnv(robot=True, trample_probability=0.1)
     env.reset()
 
-    assert env.can_forward(env.get_state(), 0) is True
+    # step() should always succeed for a robot
     obs, rewards, done, info = env.step([3])
 
     assert np.array_equal(env.agents[0].pos, [2, 2])
-    assert env.grid.get(2, 2) is env.agents[0]
     assert ('bush', 2, 2, True) in env.get_state()[3]
 
 
@@ -145,33 +204,50 @@ def test_set_state_restores_untrampled_bush():
     assert bush.trampled is False
 
 
-def test_probabilistic_bush_transition_probabilities():
-    """transition_probabilities returns 2 outcomes when trample_probability < 1."""
-    env = BushTestEnv(robot=True, trample_probability=0.6)
-    env.reset()
+# ---------------------------------------------------------------------------
+# Stochastic trampling — now applies to HUMAN agents
+# ---------------------------------------------------------------------------
 
-    state = env.get_state()
-    outcomes = env.transition_probabilities(state, [3])  # forward action
-
-    assert outcomes is not None
-    assert len(outcomes) == 2, f"Expected 2 outcomes, got {len(outcomes)}"
-    probs = sorted([p for p, _ in outcomes], reverse=True)
-    assert abs(probs[0] - 0.6) < 1e-9, f"Expected succeed prob 0.6, got {probs[0]}"
-    assert abs(probs[1] - 0.4) < 1e-9, f"Expected fail prob 0.4, got {probs[1]}"
-
-
-def test_probabilistic_bush_succeed_outcome_moves_agent():
-    """When trampling succeeds, agent moves into the cell and bush is trampled."""
-    env = BushTestEnv(robot=True, trample_probability=0.6)
+def test_robot_transition_is_always_deterministic_single_outcome():
+    """Robots always produce a single (p=1.0) outcome regardless of trample_probability."""
+    env = BushTestEnv(robot=True, trample_probability=0.3)
     env.reset()
 
     state = env.get_state()
     outcomes = env.transition_probabilities(state, [3])
 
-    # Find the succeed outcome (agent at [2,2])
+    assert outcomes is not None
+    assert len(outcomes) == 1, (
+        f"Expected 1 deterministic outcome for robot, got {len(outcomes)}"
+    )
+    assert abs(outcomes[0][0] - 1.0) < 1e-9
+
+
+def test_human_probabilistic_bush_transition_probabilities():
+    """For humans with trample_probability < 1, transition_probabilities returns 2 outcomes."""
+    env = BushTestEnv(robot=False, trample_probability=0.6)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
+
+    assert outcomes is not None
+    assert len(outcomes) == 2, f"Expected 2 outcomes for human, got {len(outcomes)}"
+    probs = sorted([p for p, _ in outcomes], reverse=True)
+    assert abs(probs[0] - 0.6) < 1e-9, f"Expected succeed prob 0.6, got {probs[0]}"
+    assert abs(probs[1] - 0.4) < 1e-9, f"Expected fail prob 0.4, got {probs[1]}"
+
+
+def test_human_probabilistic_bush_succeed_outcome_moves_agent():
+    """When human trampling succeeds, agent moves into the cell and bush is trampled."""
+    env = BushTestEnv(robot=False, trample_probability=0.6)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
+
     succeed_state = None
     for prob, s in outcomes:
-        # Restore state, set to candidate, check agent pos
         env.set_state(s)
         if np.array_equal(env.agents[0].pos, [2, 2]):
             succeed_state = (prob, s)
@@ -179,19 +255,17 @@ def test_probabilistic_bush_succeed_outcome_moves_agent():
 
     assert succeed_state is not None, "No succeed outcome found"
     assert abs(succeed_state[0] - 0.6) < 1e-9
-    # Bush should be recorded as trampled in successor state
     assert ('bush', 2, 2, True) in succeed_state[1][3]
 
 
-def test_probabilistic_bush_fail_outcome_keeps_agent():
-    """When trampling fails, agent stays put and bush remains."""
-    env = BushTestEnv(robot=True, trample_probability=0.6)
+def test_human_probabilistic_bush_fail_outcome_keeps_agent():
+    """When human trampling fails, agent stays put and bush remains."""
+    env = BushTestEnv(robot=False, trample_probability=0.6)
     env.reset()
 
     state = env.get_state()
     outcomes = env.transition_probabilities(state, [3])
 
-    # Find the fail outcome (agent still at [1,2])
     fail_state = None
     for prob, s in outcomes:
         env.set_state(s)
@@ -201,13 +275,12 @@ def test_probabilistic_bush_fail_outcome_keeps_agent():
 
     assert fail_state is not None, "No fail outcome found"
     assert abs(fail_state[0] - 0.4) < 1e-9
-    # Bush should still be untrampled
     assert ('bush', 2, 2, False) in fail_state[1][3]
 
 
-def test_deterministic_bush_has_single_outcome():
-    """With trample_probability=1.0, transition_probabilities returns a single outcome."""
-    env = BushTestEnv(robot=True, trample_probability=1.0)
+def test_human_deterministic_bush_single_outcome():
+    """With trample_probability=1.0, a human produces a single deterministic outcome."""
+    env = BushTestEnv(robot=False, trample_probability=1.0)
     env.reset()
 
     state = env.get_state()
@@ -218,16 +291,15 @@ def test_deterministic_bush_has_single_outcome():
     assert abs(outcomes[0][0] - 1.0) < 1e-9
 
 
-def test_step_consistent_with_transition_probabilities_for_probabilistic_bush():
-    """step() and transition_probabilities() produce consistent distributions."""
-    env = BushTestEnv(robot=True, trample_probability=0.5)
+def test_step_consistent_with_transition_probabilities_for_human_probabilistic_bush():
+    """step() and transition_probabilities() produce consistent distributions for humans."""
+    env = BushTestEnv(robot=False, trample_probability=0.5)
     env.reset()
 
     state = env.get_state()
     outcomes = env.transition_probabilities(state, [3])
     outcome_states = {s for _, s in outcomes}
 
-    # Run many steps and verify every resulting state is a valid outcome
     n_trials = 200
     for _ in range(n_trials):
         env.set_state(state)
@@ -238,6 +310,10 @@ def test_step_consistent_with_transition_probabilities_for_probabilistic_bush():
         )
 
 
+# ---------------------------------------------------------------------------
+# Config / map-parsed bushes
+# ---------------------------------------------------------------------------
+
 def test_probabilistic_bush_via_config():
     """trample_probability from MultiGridEnv constructor applies to map-parsed bushes."""
     env = MultiGridEnv(
@@ -247,7 +323,6 @@ def test_probabilistic_bush_via_config():
         partial_obs=False,
     )
     env.reset()
-    # Find a bush in the grid
     found_bush = None
     for y in range(env.grid.height):
         for x in range(env.grid.width):

--- a/tests/test_bush.py
+++ b/tests/test_bush.py
@@ -1,0 +1,138 @@
+"""
+Tests for robot-tramplable bushes.
+"""
+
+import numpy as np
+
+from gym_multigrid.multigrid import Agent, Bush, Grid, MultiGridEnv, Wall, World
+
+
+class BushTestEnv(MultiGridEnv):
+    """Small corridor with a bush between a robot and open floor."""
+
+    def __init__(self, robot=True):
+        agent = Agent(
+            World,
+            5 if robot else 4,
+            can_push_rocks=robot,
+            can_enter_magic_walls=robot,
+        )
+        super().__init__(
+            width=5,
+            height=5,
+            max_steps=10,
+            agents=[agent],
+            partial_obs=False,
+            objects_set=World,
+        )
+
+    def _gen_grid(self, width, height):
+        self.grid = Grid(width, height)
+        for x in range(width):
+            self.grid.set(x, 0, Wall(World))
+            self.grid.set(x, height - 1, Wall(World))
+        for y in range(height):
+            self.grid.set(0, y, Wall(World))
+            self.grid.set(width - 1, y, Wall(World))
+
+        self.agents[0].pos = np.array([1, 2])
+        self.agents[0].dir = 0
+        self.grid.set(1, 2, self.agents[0])
+        self.grid.set(2, 2, Bush(World))
+
+
+class BushHumanPassageEnv(MultiGridEnv):
+    """Robot tramples a bush, then a human can pass through the cleared cell."""
+
+    def __init__(self):
+        robot = Agent(World, 5, can_push_rocks=True, can_enter_magic_walls=True)
+        human = Agent(World, 4, can_push_rocks=False, can_enter_magic_walls=False)
+        super().__init__(
+            width=5,
+            height=5,
+            max_steps=10,
+            agents=[robot, human],
+            partial_obs=False,
+            objects_set=World,
+        )
+
+    def _gen_grid(self, width, height):
+        self.grid = Grid(width, height)
+        for x in range(width):
+            self.grid.set(x, 0, Wall(World))
+            self.grid.set(x, height - 1, Wall(World))
+        for y in range(height):
+            self.grid.set(0, y, Wall(World))
+            self.grid.set(width - 1, y, Wall(World))
+
+        self.agents[0].pos = np.array([1, 2])
+        self.agents[0].dir = 0
+        self.grid.set(1, 2, self.agents[0])
+
+        self.agents[1].pos = np.array([2, 3])
+        self.agents[1].dir = 3
+        self.grid.set(2, 3, self.agents[1])
+
+        self.grid.set(2, 2, Bush(World))
+
+
+def test_bush_creation():
+    bush = Bush(World)
+
+    assert bush.type == 'bush'
+    assert bush.color == 'green'
+    assert bush.trampled is False
+    assert not bush.can_overlap()
+    assert not bush.can_pickup()
+
+
+def test_human_cannot_enter_untrampled_bush():
+    env = BushTestEnv(robot=False)
+    env.reset()
+
+    obs, rewards, done, info = env.step([3])
+
+    assert np.array_equal(env.agents[0].pos, [1, 2])
+    bush = env.grid.get(2, 2)
+    assert bush is not None
+    assert bush.type == 'bush'
+    assert bush.trampled is False
+
+
+def test_robot_tramples_bush_and_state_tracks_it():
+    env = BushTestEnv(robot=True)
+    env.reset()
+
+    assert env.can_forward(env.get_state(), 0) is True
+    obs, rewards, done, info = env.step([3])
+
+    assert np.array_equal(env.agents[0].pos, [2, 2])
+    assert env.grid.get(2, 2) is env.agents[0]
+    assert ('bush', 2, 2, True) in env.get_state()[3]
+
+
+def test_human_can_pass_after_robot_tramples_bush():
+    env = BushHumanPassageEnv()
+    env.reset()
+
+    env.step([3, 0])  # Robot tramples bush, human waits.
+    env.step([3, 3])  # Robot leaves; human's target was occupied at step start.
+    env.step([0, 3])  # Human can now enter the cleared cell.
+
+    assert np.array_equal(env.agents[1].pos, [2, 2])
+    assert ('bush', 2, 2, True) in env.get_state()[3]
+
+
+def test_set_state_restores_untrampled_bush():
+    env = BushTestEnv(robot=True)
+    env.reset()
+    initial_state = env.get_state()
+
+    env.step([3])
+    assert ('bush', 2, 2, True) in env.get_state()[3]
+
+    env.set_state(initial_state)
+    bush = env.grid.get(2, 2)
+    assert bush is not None
+    assert bush.type == 'bush'
+    assert bush.trampled is False

--- a/tests/test_bush.py
+++ b/tests/test_bush.py
@@ -10,7 +10,7 @@ from gym_multigrid.multigrid import Agent, Bush, Grid, MultiGridEnv, Wall, World
 class BushTestEnv(MultiGridEnv):
     """Small corridor with a bush between a robot and open floor."""
 
-    def __init__(self, robot=True):
+    def __init__(self, robot=True, trample_probability=1.0):
         agent = Agent(
             World,
             5 if robot else 4,
@@ -24,6 +24,7 @@ class BushTestEnv(MultiGridEnv):
             agents=[agent],
             partial_obs=False,
             objects_set=World,
+            trample_probability=trample_probability,
         )
 
     def _gen_grid(self, width, height):
@@ -38,7 +39,7 @@ class BushTestEnv(MultiGridEnv):
         self.agents[0].pos = np.array([1, 2])
         self.agents[0].dir = 0
         self.grid.set(1, 2, self.agents[0])
-        self.grid.set(2, 2, Bush(World))
+        self.grid.set(2, 2, Bush(World, trample_probability=self.trample_probability))
 
 
 class BushHumanPassageEnv(MultiGridEnv):
@@ -82,8 +83,14 @@ def test_bush_creation():
     assert bush.type == 'bush'
     assert bush.color == 'green'
     assert bush.trampled is False
+    assert bush.trample_probability == 1.0
     assert not bush.can_overlap()
     assert not bush.can_pickup()
+
+
+def test_bush_creation_with_probability():
+    bush = Bush(World, trample_probability=0.5)
+    assert bush.trample_probability == 0.5
 
 
 def test_human_cannot_enter_untrampled_bush():
@@ -136,3 +143,119 @@ def test_set_state_restores_untrampled_bush():
     assert bush is not None
     assert bush.type == 'bush'
     assert bush.trampled is False
+
+
+def test_probabilistic_bush_transition_probabilities():
+    """transition_probabilities returns 2 outcomes when trample_probability < 1."""
+    env = BushTestEnv(robot=True, trample_probability=0.6)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])  # forward action
+
+    assert outcomes is not None
+    assert len(outcomes) == 2, f"Expected 2 outcomes, got {len(outcomes)}"
+    probs = sorted([p for p, _ in outcomes], reverse=True)
+    assert abs(probs[0] - 0.6) < 1e-9, f"Expected succeed prob 0.6, got {probs[0]}"
+    assert abs(probs[1] - 0.4) < 1e-9, f"Expected fail prob 0.4, got {probs[1]}"
+
+
+def test_probabilistic_bush_succeed_outcome_moves_agent():
+    """When trampling succeeds, agent moves into the cell and bush is trampled."""
+    env = BushTestEnv(robot=True, trample_probability=0.6)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
+
+    # Find the succeed outcome (agent at [2,2])
+    succeed_state = None
+    for prob, s in outcomes:
+        # Restore state, set to candidate, check agent pos
+        env.set_state(s)
+        if np.array_equal(env.agents[0].pos, [2, 2]):
+            succeed_state = (prob, s)
+            break
+
+    assert succeed_state is not None, "No succeed outcome found"
+    assert abs(succeed_state[0] - 0.6) < 1e-9
+    # Bush should be recorded as trampled in successor state
+    assert ('bush', 2, 2, True) in succeed_state[1][3]
+
+
+def test_probabilistic_bush_fail_outcome_keeps_agent():
+    """When trampling fails, agent stays put and bush remains."""
+    env = BushTestEnv(robot=True, trample_probability=0.6)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
+
+    # Find the fail outcome (agent still at [1,2])
+    fail_state = None
+    for prob, s in outcomes:
+        env.set_state(s)
+        if np.array_equal(env.agents[0].pos, [1, 2]):
+            fail_state = (prob, s)
+            break
+
+    assert fail_state is not None, "No fail outcome found"
+    assert abs(fail_state[0] - 0.4) < 1e-9
+    # Bush should still be untrampled
+    assert ('bush', 2, 2, False) in fail_state[1][3]
+
+
+def test_deterministic_bush_has_single_outcome():
+    """With trample_probability=1.0, transition_probabilities returns a single outcome."""
+    env = BushTestEnv(robot=True, trample_probability=1.0)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
+
+    assert outcomes is not None
+    assert len(outcomes) == 1
+    assert abs(outcomes[0][0] - 1.0) < 1e-9
+
+
+def test_step_consistent_with_transition_probabilities_for_probabilistic_bush():
+    """step() and transition_probabilities() produce consistent distributions."""
+    env = BushTestEnv(robot=True, trample_probability=0.5)
+    env.reset()
+
+    state = env.get_state()
+    outcomes = env.transition_probabilities(state, [3])
+    outcome_states = {s for _, s in outcomes}
+
+    # Run many steps and verify every resulting state is a valid outcome
+    n_trials = 200
+    for _ in range(n_trials):
+        env.set_state(state)
+        env.step([3])
+        resulting_state = env.get_state()
+        assert resulting_state in outcome_states, (
+            "step() produced a state not present in transition_probabilities() outcomes"
+        )
+
+
+def test_probabilistic_bush_via_config():
+    """trample_probability from MultiGridEnv constructor applies to map-parsed bushes."""
+    env = MultiGridEnv(
+        map="We We We We\nWe Ae Bu We\nWe We We We",
+        trample_probability=0.5,
+        objects_set=World,
+        partial_obs=False,
+    )
+    env.reset()
+    # Find a bush in the grid
+    found_bush = None
+    for y in range(env.grid.height):
+        for x in range(env.grid.width):
+            cell = env.grid.get(x, y)
+            if cell is not None and cell.type == 'bush':
+                found_bush = cell
+                break
+        if found_bush:
+            break
+    assert found_bush is not None, "No bush found in the grid"
+    assert found_bush.trample_probability == 0.5

--- a/tests/test_map_parsing.py
+++ b/tests/test_map_parsing.py
@@ -96,7 +96,7 @@ def test_all_object_types():
     """Test all object types are parsed correctly."""
     test_map = """
     We We We We We We We We We We
-    We Bl Ro La Sw Un .. .. .. We
+    We Bl Ro Bu La Sw Un .. .. We
     We Gr Kr Br Xr .. .. .. .. We
     We Lr Cr Or .. .. .. .. .. We
     We Mn Ms Mw Me Ma .. .. .. We
@@ -115,14 +115,17 @@ def test_all_object_types():
     # Check rock
     assert cells[1][2] == ('rock', {})
     
+    # Check bush
+    assert cells[1][3] == ('bush', {})
+
     # Check lava
-    assert cells[1][3] == ('lava', {})
+    assert cells[1][4] == ('lava', {})
     
     # Check switch
-    assert cells[1][4] == ('switch', {})
+    assert cells[1][5] == ('switch', {})
     
     # Check unsteady
-    assert cells[1][5] == ('unsteady', {})
+    assert cells[1][6] == ('unsteady', {})
     
     # Check goal
     assert cells[2][1] == ('goal', {'color': 'red'})

--- a/vendor/multigrid/GRIDWORLD_REFERENCE.md
+++ b/vendor/multigrid/GRIDWORLD_REFERENCE.md
@@ -346,7 +346,9 @@ Each cell in the grid can contain:
 - **Color**: Green
 - **Appearance**: Layered overlapping circles in dark and light green
 - **Properties**:
-  - Cannot be overlapped in the normal sense, but all agents can attempt to walk through it
+  - Non-overlappable: agents cannot simply step onto a bush; instead they must enter it via
+    the forward action, which triggers trampling (removing the bush). This differs from
+    overlappable terrain (e.g. unsteady ground) where the object remains after the agent steps on it.
   - Immobile (cannot be pushed)
   - **Mutable**: Trampled when any agent successfully enters; once trampled the bush is removed
     and the cell is permanently empty for all agents

--- a/vendor/multigrid/GRIDWORLD_REFERENCE.md
+++ b/vendor/multigrid/GRIDWORLD_REFERENCE.md
@@ -347,51 +347,59 @@ Each cell in the grid can contain:
 - **Appearance**: Layered overlapping circles in dark and light green
 - **Properties**:
   - Non-overlappable: agents cannot simply step onto a bush; instead they must enter it via
-    the forward action, which triggers trampling (removing the bush). This differs from
-    overlappable terrain (e.g. unsteady ground) where the object remains after the agent steps on it.
+    the forward action. For robots the bush is destroyed; for humans the bush remains.
   - Immobile (cannot be pushed)
-  - **Mutable**: Trampled when any agent successfully enters; once trampled the bush is removed
-    and the cell is permanently empty for all agents
+  - **Mutable**: Destroyed (trampled) permanently when a robot enters it; survives when a
+    human enters it
 - **Attributes**:
-  - `trampled`: Whether the bush has been trampled (default: False)
+  - `trampled`: Whether the bush has been trampled by a robot (default: False). Once True
+    the bush is permanently gone from the grid.
   - `trample_probability`: Probability (0.0 to 1.0) that a **human** (non-robot) agent's
-    forward-into-bush attempt succeeds (default: 1.0). Robots are unaffected and always succeed.
+    forward-into-bush attempt succeeds (default: 1.0). Robots are unaffected and always trample.
 - **Who Can Enter / Trample**:
   - **All agents** can attempt to enter a bush via the forward action
   - **Robot-like agents** (those for whom `can_push_rocks=True`, `can_enter_magic_walls=True`, or
-    `color='grey'`) always trample with certainty (probability 1.0), regardless of `trample_probability`
-  - **Human-like agents** succeed with probability `trample_probability` (default 1.0, i.e. certain
-    unless overridden). With probability `1 - trample_probability` they stay put.
-- **Trampling Mechanic**:
-  - Any agent uses **forward action** when facing an untrampled bush
-  - Robots: always succeed — agent moves into cell, bush trampled and removed
-  - Humans: succeed with probability `trample_probability`:
-    - With probability `trample_probability`: bush is trampled, agent moves into the cell
-    - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
-  - Trampled bush is removed from the grid; all agents can then pass freely
-- **Probabilistic Trampling** (for humans):
+    `color='grey'`) always **trample** the bush with certainty (probability 1.0), regardless of
+    `trample_probability`. The bush is permanently removed from the grid.
+  - **Human-like agents** **enter** the bush without trampling it (bush stays intact). Success
+    occurs with probability `trample_probability` (default 1.0). On success the agent occupies
+    the cell alongside the bush (like terrain); the bush is restored when the agent leaves.
+    With probability `1 - trample_probability` the attempt fails and the agent stays put.
+- **Robot Trampling Mechanic**:
+  - Robot uses **forward action** when facing an untrampled bush
+  - Always succeeds — agent moves into cell, bush `trampled=True` and removed from the grid
+  - Cell becomes permanently empty for all agents
+- **Human Entry Mechanic**:
+  - Human uses **forward action** when facing an untrampled bush
+  - With probability `trample_probability`: agent moves onto the bush cell; bush **stays** (like
+    terrain underfoot). State records `trampled=False`. When human leaves the cell the bush is
+    restored to the grid automatically.
+  - With probability `1 - trample_probability`: nothing happens; agent stays, bush unchanged.
+- **Probabilistic Entry** (for humans):
   - Set globally via `trample_probability` parameter on `MultiGridEnv` (applies to all map-parsed
     bushes) or per-bush via `Bush(world, trample_probability=p)`
   - Config file key: `trample_probability` (e.g., `trample_probability: 0.7`)
-  - Smooths the human-power reward signal: even the first cleared bush in a multi-bush path
-    increases human reachability, because each successive bush has probability `trample_probability`
-    of being traversed
+  - Smooths the human-power reward signal: each bush a human can traverse with some probability
+    increases reachability even without the robot having cleared it
 - **Special Processing Order**:
   - Human agents doing probabilistic bush entry are processed **last** (after normal, unsteady, and
     magic-wall agents). Robot bush-trampling is deterministic and processed as a normal action.
 - **Transition Probabilities**:
   - Robot forward into bush: always a single deterministic outcome (trampled, agent moves in)
   - Human forward into bush with `trample_probability == 1.0`: single deterministic outcome
+    (agent on bush cell, bush `trampled=False`)
   - Human forward into bush with `trample_probability < 1.0`: two outcomes:
-    1. Succeed (agent moves into cell, bush trampled): probability = `trample_probability`
+    1. Succeed (agent moves onto bush cell, bush stays `trampled=False`): probability = `trample_probability`
     2. Fail (agent stays, bush remains): probability = `1 - trample_probability`
 - **State Representation**:
   - Tracked in mutable objects: `('bush', x, y, trampled_bool)`
-  - `set_state()` restores both trampled and untrampled bushes correctly
+  - `trampled=True` only when a robot has entered; a human on the bush gives `trampled=False`
+  - `set_state()` restores both trampled and untrampled bushes; if an agent is on a bush cell
+    the bush is saved to `terrain_grid` so it persists correctly
 - **Use Cases**:
-  - Obstacles robots can always clear, humans only sometimes (probabilistic difficulty)
-  - Reward shaping via probabilistic clearing of multi-bush paths
-  - Smooth human-power gradients in environments with bush corridors
+  - Obstacles robots can always clear, humans sometimes enter (probabilistic difficulty)
+  - Reward shaping via probabilistic human traversal of multi-bush corridors
+  - Smooth human-power gradients: even uncleared bushes increase reachability if p > 0
 
 ### 20. Agent
 - **Type**: `agent`
@@ -532,11 +540,12 @@ There are **three sources** of stochasticity in the environment:
 - If stumbling occurs, the forward action is replaced by left+forward or right+forward (50-50 chance)
 - This introduces action-level stochasticity independent of agent ordering
 
-#### 3. Probabilistic Bush Trampling
+#### 3. Probabilistic Bush Entry (for humans)
 - When a **human** (non-robot) agent attempts to enter a bush with `trample_probability < 1.0`
-- Trampling succeeds with probability `trample_probability`; otherwise agent stays in place
-- Robot-like agents always trample with certainty and are processed deterministically
-- Probabilistic (human) trampling attempts are processed **last** in each step
+- Entry succeeds with probability `trample_probability`; otherwise agent stays in place
+- On success, the bush **stays intact** (the human occupies the cell alongside the bush)
+- Robot-like agents always trample with certainty (single deterministic outcome, bush removed)
+- Probabilistic (human) entry attempts are processed **last** in each step
 
 ### When Order Matters (Probabilistic Outcomes from Conflicts)
 
@@ -565,13 +574,14 @@ Movement becomes probabilistic when:
    - If agents target the same cell (after stumbling), none move forward
    - This creates complex probability distributions combining stumbling and conflicts
 
-### When Probabilistic Bush Trampling Matters
+### When Probabilistic Bush Entry Matters
 
-Trampling becomes stochastic only for **human** (non-robot) agents:
+Bush entry is stochastic only for **human** (non-robot) agents:
 1. **Human agent moves forward into a bush with `trample_probability < 1.0`**:
-   - With probability `trample_probability`: bush is cleared, agent moves into the cell
+   - With probability `trample_probability`: agent enters the cell; **bush stays intact**
+     (unlike robot trampling, the bush is not removed)
    - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
-   - Robot-like agents are always deterministic (always succeed) and produce a single outcome
+   - Robot-like agents always trample (destroy) the bush deterministically (single outcome)
    - This is the primary mechanism for smoothing multi-bush reward signals
 
 ### When Order Doesn't Matter (Deterministic Outcomes)

--- a/vendor/multigrid/GRIDWORLD_REFERENCE.md
+++ b/vendor/multigrid/GRIDWORLD_REFERENCE.md
@@ -340,7 +340,51 @@ Each cell in the grid can contain:
   - Remote control mechanisms where humans guide robot movement
   - Teaching scenarios where robots pre-program actions for humans to trigger
 
-### 19. Agent
+### 19. Bush
+- **Type**: `bush`
+- **Map Code**: `Bu`
+- **Color**: Green
+- **Appearance**: Layered overlapping circles in dark and light green
+- **Properties**:
+  - Cannot be overlapped (blocks movement for humans and non-trampling agents)
+  - Immobile (cannot be pushed)
+  - **Mutable**: Can be trampled by authorized robot-like agents
+  - Once trampled, the bush is removed from the grid and the cell becomes empty for all agents
+- **Attributes**:
+  - `trampled`: Whether the bush has been trampled (default: False)
+  - `trample_probability`: Probability (0.0 to 1.0) that a trampling attempt succeeds (default: 1.0)
+- **Who Can Trample**:
+  - Agents with `can_push_rocks=True`, `can_enter_magic_walls=True`, or `color='grey'`
+  - Human-like agents (yellow) cannot trample bushes
+- **Trampling Mechanic**:
+  - Authorized robot uses **forward action** when facing an untrampled bush
+  - With `trample_probability == 1.0` (default): trampling always succeeds, agent moves into the cell
+  - With `trample_probability < 1.0`: trampling is **stochastic**:
+    - With probability `trample_probability`: bush is trampled, agent moves into the cell
+    - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
+  - Trampled bush is removed from the grid; all agents can then pass through that cell freely
+- **Probabilistic Trampling**:
+  - Set via `trample_probability` parameter on `MultiGridEnv` (applies to all map-parsed bushes) or per-bush via `Bush(world, trample_probability=p)`
+  - Config file key: `trample_probability` (e.g., `trample_probability: 0.7`)
+  - Smooths the human-power reward signal: even a partially-cleared multi-bush path
+    increases human reachability, because the probability of traversing the remaining
+    bushes is higher than traversing all of them
+- **Special Processing Order**:
+  - Probabilistic bush-trampling agents are processed **last** (after normal, unsteady, and magic-wall agents)
+- **Transition Probabilities**:
+  - With `trample_probability == 1.0`: single deterministic outcome (bush trampled)
+  - With `trample_probability < 1.0`: two outcomes in `transition_probabilities()`:
+    1. Succeed (agent moves into cell, bush trampled): probability = `trample_probability`
+    2. Fail (agent stays, bush remains): probability = `1 - trample_probability`
+- **State Representation**:
+  - Tracked in mutable objects: `('bush', x, y, trampled_bool)`
+  - `set_state()` restores both trampled and untrampled bushes correctly
+- **Use Cases**:
+  - Obstacles that only robots can clear
+  - Reward shaping via probabilistic clearing of multi-bush paths
+  - Separating human and robot reachable zones
+
+### 20. Agent
 - **Type**: `agent`
 - **Color**: Red, green, blue, purple, yellow, grey (assigned by index)
 - **Properties**:
@@ -465,7 +509,7 @@ Most individual actions are **deterministic**:
 
 ### Sources of Non-Determinism
 
-There are **two sources** of stochasticity in the environment:
+There are **three sources** of stochasticity in the environment:
 
 #### 1. Agent Execution Order (Multi-Agent Conflicts)
 - When multiple agents act simultaneously, they execute in random order
@@ -478,6 +522,11 @@ There are **two sources** of stochasticity in the environment:
 - Agent may stumble with probability defined by the cell's `stumble_probability` parameter
 - If stumbling occurs, the forward action is replaced by left+forward or right+forward (50-50 chance)
 - This introduces action-level stochasticity independent of agent ordering
+
+#### 3. Probabilistic Bush Trampling
+- When an authorized robot-like agent attempts to trample a bush with `trample_probability < 1.0`
+- Trampling succeeds with probability `trample_probability`; otherwise agent stays in place
+- Trampling attempts are processed **last** in each step (after normal and unsteady agents)
 
 ### When Order Matters (Probabilistic Outcomes from Conflicts)
 
@@ -506,6 +555,14 @@ Movement becomes probabilistic when:
    - If agents target the same cell (after stumbling), none move forward
    - This creates complex probability distributions combining stumbling and conflicts
 
+### When Probabilistic Bush Trampling Matters
+
+Trampling becomes stochastic when:
+1. **Authorized agent moves forward into a bush with `trample_probability < 1.0`**:
+   - With probability `trample_probability`: bush is cleared, agent moves into the cell
+   - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
+   - This is the primary mechanism for smoothing multi-bush reward signals
+
 ### When Order Doesn't Matter (Deterministic Outcomes)
 
 Transitions remain deterministic when:
@@ -513,6 +570,7 @@ Transitions remain deterministic when:
 - All agents only rotate (rotations never interfere)
 - Agents act on independent, non-overlapping resources
 - No agents are on unsteady ground attempting forward action
+- No agents are trampling a bush with `trample_probability < 1.0`
 
 ## Object Movement
 
@@ -633,7 +691,7 @@ Episodes end when:
 - **Boxes are NOT pushable**: Must be picked up and carried
 - **Blocks ARE pushable**: Can be pushed by any agent using forward action
 - **Rocks ARE pushable with restrictions**: Can only be pushed by specific agents based on `can_push_rocks` attribute
-- **Bushes can be trampled by robots**: Robot-like agents can clear bushes, after which all agents can pass through the cell
+- **Bushes can be trampled by robots**: Robot-like agents can clear bushes after which all agents can pass through the cell; trampling can be made stochastic via `trample_probability`
 - **Unsteady ground introduces stochasticity**: Agents may stumble when moving forward on unsteady ground
 - **Magic walls introduce stochasticity**: Agents with `can_enter_magic_walls=True` can attempt entry with configurable probability from one specific direction
 - **Keys are reusable**: Not consumed when unlocking doors
@@ -647,6 +705,7 @@ Episodes end when:
   1. Agent execution order (random permutation for normal agents)
   2. Unsteady ground stumbling (configurable probability per cell)
   3. Magic wall entry (configurable probability per wall)
+  4. Bush trampling (configurable probability per bush or globally via `trample_probability`)
 - **No agent subtypes**: All agents have same capabilities, distinguished by color/index only
 
 This gridworld focuses on **multi-agent coordination** and **object manipulation**, including Sokoban-style pushing mechanics for blocks and rocks, stochastic movement on unsteady ground and magic wall entry, and **human-robot interaction** via control buttons and switches.

--- a/vendor/multigrid/GRIDWORLD_REFERENCE.md
+++ b/vendor/multigrid/GRIDWORLD_REFERENCE.md
@@ -627,12 +627,13 @@ Episodes end when:
 ## Summary
 
 **Key Points**:
-- **19 object types**: wall, floor, door, key, ball, box, goal, objgoal, lava, switch, block, rock, unsteady ground, magic wall, killbutton, pauseswitch, disablingswitch, controlbutton, and agent
+- **20 object types**: wall, floor, door, key, ball, box, goal, objgoal, lava, switch, block, rock, bush, unsteady ground, magic wall, killbutton, pauseswitch, disablingswitch, controlbutton, and agent
 - **8 standard actions**: still, left, right, forward, pickup, drop, toggle, done
 - **Single agent type**: No distinction between robot/human or different agent classes (though rocks can have agent-specific push permissions and agents can have magic wall entry capability)
 - **Boxes are NOT pushable**: Must be picked up and carried
 - **Blocks ARE pushable**: Can be pushed by any agent using forward action
 - **Rocks ARE pushable with restrictions**: Can only be pushed by specific agents based on `can_push_rocks` attribute
+- **Bushes can be trampled by robots**: Robot-like agents can clear bushes, after which all agents can pass through the cell
 - **Unsteady ground introduces stochasticity**: Agents may stumble when moving forward on unsteady ground
 - **Magic walls introduce stochasticity**: Agents with `can_enter_magic_walls=True` can attempt entry with configurable probability from one specific direction
 - **Keys are reusable**: Not consumed when unlocking doors

--- a/vendor/multigrid/GRIDWORLD_REFERENCE.md
+++ b/vendor/multigrid/GRIDWORLD_REFERENCE.md
@@ -354,31 +354,31 @@ Each cell in the grid can contain:
 - **Attributes**:
   - `trampled`: Whether the bush has been trampled by a robot (default: False). Once True
     the bush is permanently gone from the grid.
-  - `trample_probability`: Probability (0.0 to 1.0) that a **human** (non-robot) agent's
+  - `enter_bush_success_prob`: Probability (0.0 to 1.0) that a **human** (non-robot) agent's
     forward-into-bush attempt succeeds (default: 1.0). Robots are unaffected and always trample.
 - **Who Can Enter / Trample**:
   - **All agents** can attempt to enter a bush via the forward action
   - **Robot-like agents** (those for whom `can_push_rocks=True`, `can_enter_magic_walls=True`, or
     `color='grey'`) always **trample** the bush with certainty (probability 1.0), regardless of
-    `trample_probability`. The bush is permanently removed from the grid.
+    `enter_bush_success_prob`. The bush is permanently removed from the grid.
   - **Human-like agents** **enter** the bush without trampling it (bush stays intact). Success
-    occurs with probability `trample_probability` (default 1.0). On success the agent occupies
+    occurs with probability `enter_bush_success_prob` (default 1.0). On success the agent occupies
     the cell alongside the bush (like terrain); the bush is restored when the agent leaves.
-    With probability `1 - trample_probability` the attempt fails and the agent stays put.
+    With probability `1 - enter_bush_success_prob` the attempt fails and the agent stays put.
 - **Robot Trampling Mechanic**:
   - Robot uses **forward action** when facing an untrampled bush
   - Always succeeds — agent moves into cell, bush `trampled=True` and removed from the grid
   - Cell becomes permanently empty for all agents
 - **Human Entry Mechanic**:
   - Human uses **forward action** when facing an untrampled bush
-  - With probability `trample_probability`: agent moves onto the bush cell; bush **stays** (like
+  - With probability `enter_bush_success_prob`: agent moves onto the bush cell; bush **stays** (like
     terrain underfoot). State records `trampled=False`. When human leaves the cell the bush is
     restored to the grid automatically.
-  - With probability `1 - trample_probability`: nothing happens; agent stays, bush unchanged.
+  - With probability `1 - enter_bush_success_prob`: nothing happens; agent stays, bush unchanged.
 - **Probabilistic Entry** (for humans):
-  - Set globally via `trample_probability` parameter on `MultiGridEnv` (applies to all map-parsed
-    bushes) or per-bush via `Bush(world, trample_probability=p)`
-  - Config file key: `trample_probability` (e.g., `trample_probability: 0.7`)
+  - Set globally via `enter_bush_success_prob` parameter on `MultiGridEnv` (applies to all map-parsed
+    bushes) or per-bush via `Bush(world, enter_bush_success_prob=p)`
+  - Config file key: `enter_bush_success_prob` (e.g., `enter_bush_success_prob: 0.7`)
   - Smooths the human-power reward signal: each bush a human can traverse with some probability
     increases reachability even without the robot having cleared it
 - **Special Processing Order**:
@@ -386,11 +386,11 @@ Each cell in the grid can contain:
     magic-wall agents). Robot bush-trampling is deterministic and processed as a normal action.
 - **Transition Probabilities**:
   - Robot forward into bush: always a single deterministic outcome (trampled, agent moves in)
-  - Human forward into bush with `trample_probability == 1.0`: single deterministic outcome
+  - Human forward into bush with `enter_bush_success_prob == 1.0`: single deterministic outcome
     (agent on bush cell, bush `trampled=False`)
-  - Human forward into bush with `trample_probability < 1.0`: two outcomes:
-    1. Succeed (agent moves onto bush cell, bush stays `trampled=False`): probability = `trample_probability`
-    2. Fail (agent stays, bush remains): probability = `1 - trample_probability`
+  - Human forward into bush with `enter_bush_success_prob < 1.0`: two outcomes:
+    1. Succeed (agent moves onto bush cell, bush stays `trampled=False`): probability = `enter_bush_success_prob`
+    2. Fail (agent stays, bush remains): probability = `1 - enter_bush_success_prob`
 - **State Representation**:
   - Tracked in mutable objects: `('bush', x, y, trampled_bool)`
   - `trampled=True` only when a robot has entered; a human on the bush gives `trampled=False`
@@ -541,8 +541,8 @@ There are **three sources** of stochasticity in the environment:
 - This introduces action-level stochasticity independent of agent ordering
 
 #### 3. Probabilistic Bush Entry (for humans)
-- When a **human** (non-robot) agent attempts to enter a bush with `trample_probability < 1.0`
-- Entry succeeds with probability `trample_probability`; otherwise agent stays in place
+- When a **human** (non-robot) agent attempts to enter a bush with `enter_bush_success_prob < 1.0`
+- Entry succeeds with probability `enter_bush_success_prob`; otherwise agent stays in place
 - On success, the bush **stays intact** (the human occupies the cell alongside the bush)
 - Robot-like agents always trample with certainty (single deterministic outcome, bush removed)
 - Probabilistic (human) entry attempts are processed **last** in each step
@@ -577,10 +577,10 @@ Movement becomes probabilistic when:
 ### When Probabilistic Bush Entry Matters
 
 Bush entry is stochastic only for **human** (non-robot) agents:
-1. **Human agent moves forward into a bush with `trample_probability < 1.0`**:
-   - With probability `trample_probability`: agent enters the cell; **bush stays intact**
+1. **Human agent moves forward into a bush with `enter_bush_success_prob < 1.0`**:
+   - With probability `enter_bush_success_prob`: agent enters the cell; **bush stays intact**
      (unlike robot trampling, the bush is not removed)
-   - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
+   - With probability `1 - enter_bush_success_prob`: nothing happens, agent stays, bush remains
    - Robot-like agents always trample (destroy) the bush deterministically (single outcome)
    - This is the primary mechanism for smoothing multi-bush reward signals
 
@@ -591,7 +591,7 @@ Transitions remain deterministic when:
 - All agents only rotate (rotations never interfere)
 - Agents act on independent, non-overlapping resources
 - No agents are on unsteady ground attempting forward action
-- No agents are trampling a bush with `trample_probability < 1.0` (only applies to human agents; robot trampling is always deterministic)
+- No agents are trampling a bush with `enter_bush_success_prob < 1.0` (only applies to human agents; robot trampling is always deterministic)
 
 ## Object Movement
 
@@ -712,7 +712,7 @@ Episodes end when:
 - **Boxes are NOT pushable**: Must be picked up and carried
 - **Blocks ARE pushable**: Can be pushed by any agent using forward action
 - **Rocks ARE pushable with restrictions**: Can only be pushed by specific agents based on `can_push_rocks` attribute
-- **Bushes can be entered by all agents**: Robots always trample with certainty; humans succeed with configurable `trample_probability` (default 1.0)
+- **Bushes can be entered by all agents**: Robots always trample with certainty; humans succeed with configurable `enter_bush_success_prob` (default 1.0)
 - **Unsteady ground introduces stochasticity**: Agents may stumble when moving forward on unsteady ground
 - **Magic walls introduce stochasticity**: Agents with `can_enter_magic_walls=True` can attempt entry with configurable probability from one specific direction
 - **Keys are reusable**: Not consumed when unlocking doors
@@ -726,7 +726,7 @@ Episodes end when:
   1. Agent execution order (random permutation for normal agents)
   2. Unsteady ground stumbling (configurable probability per cell)
   3. Magic wall entry (configurable probability per wall)
-  4. Human bush entry (configurable probability per bush or globally via `trample_probability`; robots always trample deterministically)
+  4. Human bush entry (configurable probability per bush or globally via `enter_bush_success_prob`; robots always trample deterministically)
 - **No agent subtypes**: All agents have same capabilities, distinguished by color/index only
 
 This gridworld focuses on **multi-agent coordination** and **object manipulation**, including Sokoban-style pushing mechanics for blocks and rocks, stochastic movement on unsteady ground and magic wall entry, and **human-robot interaction** via control buttons and switches.

--- a/vendor/multigrid/GRIDWORLD_REFERENCE.md
+++ b/vendor/multigrid/GRIDWORLD_REFERENCE.md
@@ -346,43 +346,50 @@ Each cell in the grid can contain:
 - **Color**: Green
 - **Appearance**: Layered overlapping circles in dark and light green
 - **Properties**:
-  - Cannot be overlapped (blocks movement for humans and non-trampling agents)
+  - Cannot be overlapped in the normal sense, but all agents can attempt to walk through it
   - Immobile (cannot be pushed)
-  - **Mutable**: Can be trampled by authorized robot-like agents
-  - Once trampled, the bush is removed from the grid and the cell becomes empty for all agents
+  - **Mutable**: Trampled when any agent successfully enters; once trampled the bush is removed
+    and the cell is permanently empty for all agents
 - **Attributes**:
   - `trampled`: Whether the bush has been trampled (default: False)
-  - `trample_probability`: Probability (0.0 to 1.0) that a trampling attempt succeeds (default: 1.0)
-- **Who Can Trample**:
-  - Agents with `can_push_rocks=True`, `can_enter_magic_walls=True`, or `color='grey'`
-  - Human-like agents (yellow) cannot trample bushes
+  - `trample_probability`: Probability (0.0 to 1.0) that a **human** (non-robot) agent's
+    forward-into-bush attempt succeeds (default: 1.0). Robots are unaffected and always succeed.
+- **Who Can Enter / Trample**:
+  - **All agents** can attempt to enter a bush via the forward action
+  - **Robot-like agents** (those for whom `can_push_rocks=True`, `can_enter_magic_walls=True`, or
+    `color='grey'`) always trample with certainty (probability 1.0), regardless of `trample_probability`
+  - **Human-like agents** succeed with probability `trample_probability` (default 1.0, i.e. certain
+    unless overridden). With probability `1 - trample_probability` they stay put.
 - **Trampling Mechanic**:
-  - Authorized robot uses **forward action** when facing an untrampled bush
-  - With `trample_probability == 1.0` (default): trampling always succeeds, agent moves into the cell
-  - With `trample_probability < 1.0`: trampling is **stochastic**:
+  - Any agent uses **forward action** when facing an untrampled bush
+  - Robots: always succeed — agent moves into cell, bush trampled and removed
+  - Humans: succeed with probability `trample_probability`:
     - With probability `trample_probability`: bush is trampled, agent moves into the cell
     - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
-  - Trampled bush is removed from the grid; all agents can then pass through that cell freely
-- **Probabilistic Trampling**:
-  - Set via `trample_probability` parameter on `MultiGridEnv` (applies to all map-parsed bushes) or per-bush via `Bush(world, trample_probability=p)`
+  - Trampled bush is removed from the grid; all agents can then pass freely
+- **Probabilistic Trampling** (for humans):
+  - Set globally via `trample_probability` parameter on `MultiGridEnv` (applies to all map-parsed
+    bushes) or per-bush via `Bush(world, trample_probability=p)`
   - Config file key: `trample_probability` (e.g., `trample_probability: 0.7`)
-  - Smooths the human-power reward signal: even a partially-cleared multi-bush path
-    increases human reachability, because the probability of traversing the remaining
-    bushes is higher than traversing all of them
+  - Smooths the human-power reward signal: even the first cleared bush in a multi-bush path
+    increases human reachability, because each successive bush has probability `trample_probability`
+    of being traversed
 - **Special Processing Order**:
-  - Probabilistic bush-trampling agents are processed **last** (after normal, unsteady, and magic-wall agents)
+  - Human agents doing probabilistic bush entry are processed **last** (after normal, unsteady, and
+    magic-wall agents). Robot bush-trampling is deterministic and processed as a normal action.
 - **Transition Probabilities**:
-  - With `trample_probability == 1.0`: single deterministic outcome (bush trampled)
-  - With `trample_probability < 1.0`: two outcomes in `transition_probabilities()`:
+  - Robot forward into bush: always a single deterministic outcome (trampled, agent moves in)
+  - Human forward into bush with `trample_probability == 1.0`: single deterministic outcome
+  - Human forward into bush with `trample_probability < 1.0`: two outcomes:
     1. Succeed (agent moves into cell, bush trampled): probability = `trample_probability`
     2. Fail (agent stays, bush remains): probability = `1 - trample_probability`
 - **State Representation**:
   - Tracked in mutable objects: `('bush', x, y, trampled_bool)`
   - `set_state()` restores both trampled and untrampled bushes correctly
 - **Use Cases**:
-  - Obstacles that only robots can clear
+  - Obstacles robots can always clear, humans only sometimes (probabilistic difficulty)
   - Reward shaping via probabilistic clearing of multi-bush paths
-  - Separating human and robot reachable zones
+  - Smooth human-power gradients in environments with bush corridors
 
 ### 20. Agent
 - **Type**: `agent`
@@ -524,9 +531,10 @@ There are **three sources** of stochasticity in the environment:
 - This introduces action-level stochasticity independent of agent ordering
 
 #### 3. Probabilistic Bush Trampling
-- When an authorized robot-like agent attempts to trample a bush with `trample_probability < 1.0`
+- When a **human** (non-robot) agent attempts to enter a bush with `trample_probability < 1.0`
 - Trampling succeeds with probability `trample_probability`; otherwise agent stays in place
-- Trampling attempts are processed **last** in each step (after normal and unsteady agents)
+- Robot-like agents always trample with certainty and are processed deterministically
+- Probabilistic (human) trampling attempts are processed **last** in each step
 
 ### When Order Matters (Probabilistic Outcomes from Conflicts)
 
@@ -557,10 +565,11 @@ Movement becomes probabilistic when:
 
 ### When Probabilistic Bush Trampling Matters
 
-Trampling becomes stochastic when:
-1. **Authorized agent moves forward into a bush with `trample_probability < 1.0`**:
+Trampling becomes stochastic only for **human** (non-robot) agents:
+1. **Human agent moves forward into a bush with `trample_probability < 1.0`**:
    - With probability `trample_probability`: bush is cleared, agent moves into the cell
    - With probability `1 - trample_probability`: nothing happens, agent stays, bush remains
+   - Robot-like agents are always deterministic (always succeed) and produce a single outcome
    - This is the primary mechanism for smoothing multi-bush reward signals
 
 ### When Order Doesn't Matter (Deterministic Outcomes)
@@ -570,7 +579,7 @@ Transitions remain deterministic when:
 - All agents only rotate (rotations never interfere)
 - Agents act on independent, non-overlapping resources
 - No agents are on unsteady ground attempting forward action
-- No agents are trampling a bush with `trample_probability < 1.0`
+- No agents are trampling a bush with `trample_probability < 1.0` (only applies to human agents; robot trampling is always deterministic)
 
 ## Object Movement
 
@@ -691,7 +700,7 @@ Episodes end when:
 - **Boxes are NOT pushable**: Must be picked up and carried
 - **Blocks ARE pushable**: Can be pushed by any agent using forward action
 - **Rocks ARE pushable with restrictions**: Can only be pushed by specific agents based on `can_push_rocks` attribute
-- **Bushes can be trampled by robots**: Robot-like agents can clear bushes after which all agents can pass through the cell; trampling can be made stochastic via `trample_probability`
+- **Bushes can be entered by all agents**: Robots always trample with certainty; humans succeed with configurable `trample_probability` (default 1.0)
 - **Unsteady ground introduces stochasticity**: Agents may stumble when moving forward on unsteady ground
 - **Magic walls introduce stochasticity**: Agents with `can_enter_magic_walls=True` can attempt entry with configurable probability from one specific direction
 - **Keys are reusable**: Not consumed when unlocking doors
@@ -705,7 +714,7 @@ Episodes end when:
   1. Agent execution order (random permutation for normal agents)
   2. Unsteady ground stumbling (configurable probability per cell)
   3. Magic wall entry (configurable probability per wall)
-  4. Bush trampling (configurable probability per bush or globally via `trample_probability`)
+  4. Human bush entry (configurable probability per bush or globally via `trample_probability`; robots always trample deterministically)
 - **No agent subtypes**: All agents have same capabilities, distinguished by color/index only
 
 This gridworld focuses on **multi-agent coordination** and **object manipulation**, including Sokoban-style pushing mechanics for blocks and rocks, stochastic movement on unsteady ground and magic wall entry, and **human-robot interaction** via control buttons and switches.

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -1841,17 +1841,24 @@ class Rock(WorldObj):
 
 class Bush(WorldObj):
     """
-    Dense bush that blocks humans until a robot tramples it.
+    Dense bush that all agents can attempt to walk through.
 
-    A bush is mutable but immobile. Before trampling it is non-overlappable.
-    When an authorized robot-like agent moves forward into it, the bush is
-    marked trampled and removed from the grid, making the cell empty for all
-    agents afterwards.
+    A bush is mutable but immobile. It is non-overlappable in the normal
+    sense, but all agents can attempt to enter it via the forward action:
 
-    trample_probability: Probability (0.0 to 1.0) that a trampling attempt
-        succeeds. At 1.0 (default) trampling is certain. Values below 1.0
-        make trampling stochastic, which smooths the human-power reward
-        signal—partially cleared paths already increase reachability.
+    - Robot-like agents (``can_be_trampled_by`` returns True) always trample
+      the bush with certainty and move into the cell.
+    - All other agents (humans) trample the bush with probability
+      ``trample_probability`` (default 1.0, i.e. certain by default).
+
+    When trampling succeeds, the bush is removed from the grid and the cell
+    becomes empty for all agents afterwards.
+
+    trample_probability: Probability (0.0 to 1.0) that a non-robot (human)
+        agent's trampling attempt succeeds. Robots are unaffected—they always
+        succeed. Values below 1.0 make human entry stochastic, which smooths
+        the human-power reward signal—partially cleared paths already increase
+        reachability.
     """
 
     def __init__(self, world, trampled=False, trample_probability=1.0):
@@ -3616,7 +3623,9 @@ class MultiGridEnv(WorldModel):
             return can_push
 
         if fwd_cell.type == 'bush':
-            return fwd_cell.can_be_trampled_by(agent)
+            # All agents can attempt to enter a bush.
+            # Robots always succeed; humans succeed with trample_probability.
+            return True
         
         # Check for magic walls
         if fwd_cell.type == 'magicwall' and fwd_cell.active:
@@ -3744,10 +3753,12 @@ class MultiGridEnv(WorldModel):
         self.grid.set(*self.agents[agent_idx].pos, self.agents[agent_idx])
 
     def _trample_bush(self, agent_idx, target_pos, bush):
-        """Trample a bush and move the agent into its now-empty cell."""
-        if not bush.can_be_trampled_by(self.agents[agent_idx]):
-            return False
-
+        """Trample a bush and move the agent into its now-empty cell.
+        
+        This should only be called when trampling is permitted (either a
+        robot-like agent, or a human whose stochastic outcome has already
+        been resolved to 'succeed').
+        """
         bush.trampled = True
         self.grid.set(*target_pos, None)
         self._move_agent_to_cell(agent_idx, target_pos, None)
@@ -4238,16 +4249,20 @@ class MultiGridEnv(WorldModel):
     def _is_probabilistic_bush_trample(self, agent_idx, fwd_cell):
         """
         Return True when an agent facing fwd_cell would perform a stochastic bush trampling.
-        
-        A trampling is stochastic when the cell is an untrampled bush that the agent can
-        trample and whose trample_probability is strictly less than 1.0.
+
+        Robots (agents for which ``fwd_cell.can_be_trampled_by()`` returns True) always
+        trample with certainty — they are never stochastic.  Only non-robot (human) agents
+        facing an untrampled bush whose ``trample_probability`` is strictly less than 1.0
+        produce a stochastic transition.
         """
-        return (
-            fwd_cell is not None and
-            fwd_cell.type == 'bush' and
-            fwd_cell.can_be_trampled_by(self.agents[agent_idx]) and
-            fwd_cell.trample_probability < 1.0
-        )
+        if fwd_cell is None or fwd_cell.type != 'bush':
+            return False
+        agent = self.agents[agent_idx]
+        # Robots always succeed with certainty - not stochastic
+        if fwd_cell.can_be_trampled_by(agent):
+            return False
+        # Human agent: stochastic if trample_probability < 1.0
+        return fwd_cell.trample_probability < 1.0
     
     def _categorize_agents(self, actions, active_agents=None):
         """

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -1843,22 +1843,25 @@ class Bush(WorldObj):
     """
     Dense bush that all agents can attempt to walk through.
 
-    A bush is mutable but immobile. It is non-overlappable in the normal
-    sense, but all agents can attempt to enter it via the forward action:
+    A bush is mutable but immobile. All agents can attempt to enter it via the
+    forward action, but the two agent types interact with it differently:
 
-    - Robot-like agents (``can_be_trampled_by`` returns True) always trample
-      the bush with certainty and move into the cell.
-    - All other agents (humans) trample the bush with probability
-      ``trample_probability`` (default 1.0, i.e. certain by default).
+    - **Robot-like agents** (``can_be_trampled_by`` returns True) **trample** the
+      bush: it is permanently removed from the grid and the cell becomes empty.
+      Robots always trample with certainty, regardless of ``trample_probability``.
 
-    When trampling succeeds, the bush is removed from the grid and the cell
-    becomes empty for all agents afterwards.
+    - **Human agents** (all others) **enter** the bush without trampling it: the
+      bush stays intact. The agent occupies the cell alongside the bush (like
+      terrain), and the bush is restored to the grid when the human leaves the
+      cell. Success is stochastic: it occurs with probability
+      ``trample_probability`` (default 1.0, i.e. always succeeds by default).
+      When the attempt fails the agent stays put and the bush is unchanged.
 
-    trample_probability: Probability (0.0 to 1.0) that a non-robot (human)
-        agent's trampling attempt succeeds. Robots are unaffected—they always
-        succeed. Values below 1.0 make human entry stochastic, which smooths
-        the human-power reward signal—partially cleared paths already increase
-        reachability.
+    trample_probability: Probability (0.0 to 1.0) that a human agent's forward
+        attempt to enter a bush succeeds. Robots are unaffected — they always
+        trample with certainty. Values below 1.0 make human entry stochastic,
+        which smooths the human-power reward signal: even partial bush paths
+        increase reachability.
     """
 
     def __init__(self, world, trampled=False, trample_probability=1.0):
@@ -3755,9 +3758,8 @@ class MultiGridEnv(WorldModel):
     def _trample_bush(self, agent_idx, target_pos, bush):
         """Trample a bush and move the agent into its now-empty cell.
 
-        This should only be called when trampling is permitted (either a
-        robot-like agent, or a human whose stochastic outcome has already
-        been resolved to 'succeed').
+        Only called for robot-like agents (can_be_trampled_by returns True).
+        The bush is permanently removed from the grid.
 
         Args:
             agent_idx: Index of the agent doing the trampling.
@@ -3770,6 +3772,33 @@ class MultiGridEnv(WorldModel):
         bush.trampled = True
         self.grid.set(*target_pos, None)
         self._move_agent_to_cell(agent_idx, target_pos, None)
+        return True
+
+    def _enter_bush(self, agent_idx, target_pos, bush):
+        """Move a human agent onto a bush without trampling it.
+
+        The bush stays intact. It is saved to terrain_grid so it persists
+        under the agent and is restored to the grid when the agent leaves the
+        cell — exactly the same mechanism used for unsteady ground and magic
+        walls.
+
+        Only called for non-robot (human) agents when their bush-entry attempt
+        has already been resolved to 'succeed'.
+
+        Args:
+            agent_idx: Index of the agent entering the bush.
+            target_pos: Grid position (x, y) of the bush cell.
+            bush: The Bush object at target_pos.
+
+        Returns:
+            bool: Always True (entry always succeeds when this is called).
+        """
+        # Pre-save the bush to terrain_grid so _move_agent_to_cell keeps it.
+        # _move_agent_to_cell only auto-saves cells with can_overlap() == True;
+        # by pre-saving we ensure the bush survives the move (same pattern as
+        # magic wall entry in _process_magic_wall_agents).
+        self.terrain_grid.set(*target_pos, bush)
+        self._move_agent_to_cell(agent_idx, target_pos, bush)
         return True
     
     def _handle_switch(self, i, rewards, fwd_pos, fwd_cell):
@@ -4024,7 +4053,10 @@ class MultiGridEnv(WorldModel):
                     self._reward(agent_idx, rewards, 1)
                     self._move_agent_to_cell(agent_idx, fwd_pos, fwd_cell)
                 elif fwd_cell.type == 'bush':
-                    self._trample_bush(agent_idx, fwd_pos, fwd_cell)
+                    if fwd_cell.can_be_trampled_by(self.agents[agent_idx]):
+                        self._trample_bush(agent_idx, fwd_pos, fwd_cell)
+                    else:
+                        self._enter_bush(agent_idx, fwd_pos, fwd_cell)
                 elif fwd_cell.type == 'switch':
                     self._handle_switch(agent_idx, rewards, fwd_pos, fwd_cell)
                     self._move_agent_to_cell(agent_idx, fwd_pos, fwd_cell)
@@ -4185,7 +4217,10 @@ class MultiGridEnv(WorldModel):
                         self._reward(i, rewards, 1)
                         can_move = True
                     elif fwd_cell.type == 'bush':
-                        can_move = self._trample_bush(i, fwd_pos, fwd_cell)
+                        if fwd_cell.can_be_trampled_by(self.agents[i]):
+                            can_move = self._trample_bush(i, fwd_pos, fwd_cell)
+                        else:
+                            can_move = self._enter_bush(i, fwd_pos, fwd_cell)
                     elif fwd_cell.type == 'switch':
                         self._handle_switch(i, rewards, fwd_pos, fwd_cell)
                         can_move = True
@@ -5169,6 +5204,11 @@ class MultiGridEnv(WorldModel):
                     self.terrain_grid.set(*agent.pos, current_cell)
                     # Derive on_unsteady_ground from the terrain
                     agent.on_unsteady_ground = (current_cell.type == 'unsteadyground')
+                elif current_cell is not None and current_cell.type == 'bush':
+                    # Human agent is on an untrampled bush — the bush persists as
+                    # terrain under the agent (same pattern as magic wall entry).
+                    self.terrain_grid.set(*agent.pos, current_cell)
+                    agent.on_unsteady_ground = False
                 else:
                     self.terrain_grid.set(*agent.pos, None)
                     agent.on_unsteady_ground = False
@@ -6139,18 +6179,19 @@ class MultiGridEnv(WorldModel):
                         fwd_cell.active = False
                 # If outcome is 'fail', agent stays in place and wall stays magic (no action)
         
-        # Process bush trampling agents (deterministic based on pre-sampled outcome)
+        # Process bush agents (deterministic based on pre-sampled outcome).
+        # Agents in bush_agents_list are always non-robot (human) agents —
+        # robots are placed in normal_agents and handled deterministically above.
+        # On success, the human enters the bush without trampling it (bush stays).
         if bush_agents_list:
             for i in bush_agents_list:
                 outcome = bush_outcomes[i]
                 if outcome == 'succeed':
-                    # Trampling succeeds: remove bush and move agent into the cell
+                    # Human enters bush: bush stays, agent occupies the cell alongside it.
                     fwd_pos = self.agents[i].front_pos
                     fwd_cell = self.grid.get(*fwd_pos)
                     if fwd_cell is not None and fwd_cell.type == 'bush':
-                        fwd_cell.trampled = True
-                        self.grid.set(*fwd_pos, None)
-                        self._move_agent_to_cell(i, fwd_pos, None)
+                        self._enter_bush(i, fwd_pos, fwd_cell)
                 # If outcome is 'fail', agent stays in place and bush remains (no action)
         
         # Check if max steps reached

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -1857,7 +1857,9 @@ class Bush(WorldObj):
     def __init__(self, world, trampled=False, trample_probability=1.0):
         super(Bush, self).__init__(world, 'bush', 'green')
         self.trampled = trampled
-        assert 0.0 <= trample_probability <= 1.0, "trample_probability must be between 0.0 and 1.0"
+        assert 0.0 <= trample_probability <= 1.0, (
+            f"trample_probability must be between 0.0 and 1.0, got {trample_probability}"
+        )
         self.trample_probability = trample_probability
 
     def can_overlap(self):
@@ -4233,6 +4235,20 @@ class MultiGridEnv(WorldModel):
         
         return done
     
+    def _is_probabilistic_bush_trample(self, agent_idx, fwd_cell):
+        """
+        Return True when an agent facing fwd_cell would perform a stochastic bush trampling.
+        
+        A trampling is stochastic when the cell is an untrampled bush that the agent can
+        trample and whose trample_probability is strictly less than 1.0.
+        """
+        return (
+            fwd_cell is not None and
+            fwd_cell.type == 'bush' and
+            fwd_cell.can_be_trampled_by(self.agents[agent_idx]) and
+            fwd_cell.trample_probability < 1.0
+        )
+    
     def _categorize_agents(self, actions, active_agents=None):
         """
         Helper function to categorize agents into normal, unsteady-forward, magic-wall-entry, and bush-trampling groups.
@@ -4302,9 +4318,7 @@ class MultiGridEnv(WorldModel):
             if actions[i] == self.actions.forward:
                 fwd_pos = self.agents[i].front_pos
                 fwd_cell = self.grid.get(*fwd_pos)
-                if (fwd_cell is not None and fwd_cell.type == 'bush' and
-                        fwd_cell.can_be_trampled_by(self.agents[i]) and
-                        fwd_cell.trample_probability < 1.0):
+                if self._is_probabilistic_bush_trample(i, fwd_cell):
                     bush_agents.append(i)
                     continue
                 
@@ -5415,11 +5429,8 @@ class MultiGridEnv(WorldModel):
                                 is_stochastic = True
                     if not is_stochastic:
                         # Check if agent is trampling a probabilistic bush
-                        fwd_pos = self.agents[agent_idx].front_pos
-                        fwd_cell = self.grid.get(*fwd_pos)
-                        if (fwd_cell is not None and fwd_cell.type == 'bush' and
-                                fwd_cell.can_be_trampled_by(self.agents[agent_idx]) and
-                                fwd_cell.trample_probability < 1.0):
+                        fwd_cell = self.grid.get(*self.agents[agent_idx].front_pos)
+                        if self._is_probabilistic_bush_trample(agent_idx, fwd_cell):
                             is_stochastic = True
             
             if not is_stochastic:
@@ -5448,11 +5459,7 @@ class MultiGridEnv(WorldModel):
                         fwd_cell.type == 'magicwall' and
                         (self.agents[i].dir + 2) % 4 == fwd_cell.magic_side):
                     return True
-                if (fwd_cell.type == 'bush' and
-                        fwd_cell.can_be_trampled_by(self.agents[i]) and
-                        fwd_cell.trample_probability < 1.0):
-                    return True
-                return False
+                return self._is_probabilistic_bush_trample(i, fwd_cell)
             has_stochastic = any(_is_stochastic_forward(i) for i in active_agents)
             if not has_stochastic:
                 # Rotations are commutative and no stochastic agents - result is deterministic
@@ -6038,6 +6045,10 @@ class MultiGridEnv(WorldModel):
                     unsteady_forward_agents_list.append(i)
                     unsteady_outcomes_dict[i] = outcome_type
             elif not self._is_still_action(action):
+                # The categorization below is mutually exclusive by construction:
+                # _categorize_agents() puts each agent in exactly one bucket (magic_wall,
+                # bush, unsteady, or normal) so an agent index can appear in at most one of
+                # magic_wall_outcomes and bush_outcomes.
                 # Check if this is a magic wall agent
                 if magic_wall_outcomes and i in magic_wall_outcomes:
                     magic_wall_agents_list.append(i)

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -1848,29 +1848,29 @@ class Bush(WorldObj):
 
     - **Robot-like agents** (``can_be_trampled_by`` returns True) **trample** the
       bush: it is permanently removed from the grid and the cell becomes empty.
-      Robots always trample with certainty, regardless of ``trample_probability``.
+      Robots always trample with certainty, regardless of ``enter_bush_success_prob``.
 
     - **Human agents** (all others) **enter** the bush without trampling it: the
       bush stays intact. The agent occupies the cell alongside the bush (like
       terrain), and the bush is restored to the grid when the human leaves the
       cell. Success is stochastic: it occurs with probability
-      ``trample_probability`` (default 1.0, i.e. always succeeds by default).
+      ``enter_bush_success_prob`` (default 1.0, i.e. always succeeds by default).
       When the attempt fails the agent stays put and the bush is unchanged.
 
-    trample_probability: Probability (0.0 to 1.0) that a human agent's forward
+    enter_bush_success_prob: Probability (0.0 to 1.0) that a human agent's forward
         attempt to enter a bush succeeds. Robots are unaffected — they always
         trample with certainty. Values below 1.0 make human entry stochastic,
         which smooths the human-power reward signal: even partial bush paths
         increase reachability.
     """
 
-    def __init__(self, world, trampled=False, trample_probability=1.0):
+    def __init__(self, world, trampled=False, enter_bush_success_prob=1.0):
         super(Bush, self).__init__(world, 'bush', 'green')
         self.trampled = trampled
-        assert 0.0 <= trample_probability <= 1.0, (
-            f"trample_probability must be between 0.0 and 1.0, got {trample_probability}"
+        assert 0.0 <= enter_bush_success_prob <= 1.0, (
+            f"enter_bush_success_prob must be between 0.0 and 1.0, got {enter_bush_success_prob}"
         )
-        self.trample_probability = trample_probability
+        self.enter_bush_success_prob = enter_bush_success_prob
 
     def can_overlap(self):
         return False
@@ -2767,7 +2767,7 @@ def _parse_cell(cell_str, objects_set):
         raise ValueError(f"Unknown cell type: {cell_str}")
 
 
-def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_probability=0.5, solidify_probability=0.1, trample_probability=1.0):
+def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_probability=0.5, solidify_probability=0.1, enter_bush_success_prob=1.0):
     """
     Create a WorldObj from a cell specification.
     
@@ -2777,7 +2777,7 @@ def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_pr
         actions_set: The Actions class to use (optional, needed for ControlButton)
         stumble_probability: Default stumble probability for UnsteadyGround (0.0 to 1.0)
         solidify_probability: Default solidify probability for MagicWall (0.0 to 1.0)
-        trample_probability: Default trample probability for Bush (0.0 to 1.0)
+        enter_bush_success_prob: Default probability for a human agent to successfully enter a Bush (0.0 to 1.0)
         
     Returns:
         WorldObj or None for empty cells
@@ -2795,7 +2795,7 @@ def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_pr
         return Rock(objects_set)
     elif obj_type == 'bush':
         return Bush(objects_set, trampled=params.get('trampled', False),
-                    trample_probability=params.get('trample_probability', trample_probability))
+                    enter_bush_success_prob=params.get('enter_bush_success_prob', enter_bush_success_prob))
     elif obj_type == 'lava':
         return Lava(objects_set)
     elif obj_type == 'switch':
@@ -2899,7 +2899,7 @@ class MultiGridEnv(WorldModel):
             config=None,
             stumble_probability=0.5,
             solidify_probability=0.1,
-            trample_probability=1.0
+            enter_bush_success_prob=1.0
     ):
         """
         Initialize a MultiGridEnv.
@@ -2933,7 +2933,7 @@ class MultiGridEnv(WorldModel):
                    If both config and config_file are provided, config_file takes precedence.
             stumble_probability: Default probability of stumbling on UnsteadyGround (0.0 to 1.0)
             solidify_probability: Default probability of MagicWall solidifying on failed entry (0.0 to 1.0)
-            trample_probability: Default probability that a robot successfully tramples a Bush (0.0 to 1.0)
+            enter_bush_success_prob: Default probability that a human agent successfully enters a Bush (0.0 to 1.0). Robots always trample with certainty regardless of this value.
         """
         # Load config from config file or dict if provided
         if config_file is not None:
@@ -2973,8 +2973,8 @@ class MultiGridEnv(WorldModel):
                 stumble_probability = config['stumble_probability']
             if solidify_probability == 0.1 and 'solidify_probability' in config:  # default: 0.1
                 solidify_probability = config['solidify_probability']
-            if trample_probability == 1.0 and 'trample_probability' in config:  # default: 1.0
-                trample_probability = config['trample_probability']
+            if enter_bush_success_prob == 1.0 and 'enter_bush_success_prob' in config:  # default: 1.0
+                enter_bush_success_prob = config['enter_bush_success_prob']
             # Handle action_class from config
             if actions_set is Actions and 'action_class' in config:
                 action_class_name = config['action_class']
@@ -3010,8 +3010,8 @@ class MultiGridEnv(WorldModel):
         # Store solidify_probability for use by MagicWall objects
         self.solidify_probability = solidify_probability
         
-        # Store trample_probability as the default for Bush objects
-        self.trample_probability = trample_probability
+        # Store enter_bush_success_prob as the default for Bush objects
+        self.enter_bush_success_prob = enter_bush_success_prob
         
         # Initialize RNG early so we can use it for random orientations
         # This is done before reset() to allow random orientations to be drawn in __init__
@@ -3478,7 +3478,7 @@ class MultiGridEnv(WorldModel):
                     obj = create_object_from_spec(cell_spec, self.objects, self.actions, 
                                                   stumble_probability=self.stumble_probability,
                                                   solidify_probability=self.solidify_probability,
-                                                  trample_probability=self.trample_probability)
+                                                  enter_bush_success_prob=self.enter_bush_success_prob)
                     if obj is not None:
                         self.grid.set(x, y, obj)
         
@@ -3627,7 +3627,7 @@ class MultiGridEnv(WorldModel):
 
         if fwd_cell.type == 'bush':
             # All agents can attempt to enter a bush.
-            # Robots always succeed; humans succeed with trample_probability.
+            # Robots always succeed; humans succeed with enter_bush_success_prob.
             return True
         
         # Check for magic walls
@@ -4295,7 +4295,7 @@ class MultiGridEnv(WorldModel):
 
         Robots (agents for which ``fwd_cell.can_be_trampled_by()`` returns True) always
         trample with certainty — they are never stochastic.  Only non-robot (human) agents
-        facing an untrampled bush whose ``trample_probability`` is strictly less than 1.0
+        facing an untrampled bush whose ``enter_bush_success_prob`` is strictly less than 1.0
         produce a stochastic transition.
         """
         if fwd_cell is None or fwd_cell.type != 'bush':
@@ -4304,8 +4304,8 @@ class MultiGridEnv(WorldModel):
         # Robots always succeed with certainty - not stochastic
         if fwd_cell.can_be_trampled_by(agent):
             return False
-        # Human agent: stochastic if trample_probability < 1.0
-        return fwd_cell.trample_probability < 1.0
+        # Human agent: stochastic if enter_bush_success_prob < 1.0
+        return fwd_cell.enter_bush_success_prob < 1.0
     
     def _categorize_agents(self, actions, active_agents=None):
         """
@@ -5607,7 +5607,7 @@ class MultiGridEnv(WorldModel):
         for agent_idx in bush_agents:
             fwd_pos = self.agents[agent_idx].front_pos
             fwd_cell = self.grid.get(*fwd_pos)
-            trample_prob = fwd_cell.trample_probability if fwd_cell else 1.0
+            trample_prob = fwd_cell.enter_bush_success_prob if fwd_cell else 1.0
             outcomes = [
                 (trample_prob, 'succeed'),
                 (1.0 - trample_prob, 'fail'),

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -3754,10 +3754,18 @@ class MultiGridEnv(WorldModel):
 
     def _trample_bush(self, agent_idx, target_pos, bush):
         """Trample a bush and move the agent into its now-empty cell.
-        
+
         This should only be called when trampling is permitted (either a
         robot-like agent, or a human whose stochastic outcome has already
         been resolved to 'succeed').
+
+        Args:
+            agent_idx: Index of the agent doing the trampling.
+            target_pos: Grid position (x, y) of the bush to trample.
+            bush: The Bush object at target_pos.
+        
+        Returns:
+            bool: Always True (trampling always succeeds when this is called).
         """
         bush.trampled = True
         self.grid.set(*target_pos, None)

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -1847,11 +1847,18 @@ class Bush(WorldObj):
     When an authorized robot-like agent moves forward into it, the bush is
     marked trampled and removed from the grid, making the cell empty for all
     agents afterwards.
+
+    trample_probability: Probability (0.0 to 1.0) that a trampling attempt
+        succeeds. At 1.0 (default) trampling is certain. Values below 1.0
+        make trampling stochastic, which smooths the human-power reward
+        signal—partially cleared paths already increase reachability.
     """
 
-    def __init__(self, world, trampled=False):
+    def __init__(self, world, trampled=False, trample_probability=1.0):
         super(Bush, self).__init__(world, 'bush', 'green')
         self.trampled = trampled
+        assert 0.0 <= trample_probability <= 1.0, "trample_probability must be between 0.0 and 1.0"
+        self.trample_probability = trample_probability
 
     def can_overlap(self):
         return False
@@ -2748,7 +2755,7 @@ def _parse_cell(cell_str, objects_set):
         raise ValueError(f"Unknown cell type: {cell_str}")
 
 
-def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_probability=0.5, solidify_probability=0.1):
+def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_probability=0.5, solidify_probability=0.1, trample_probability=1.0):
     """
     Create a WorldObj from a cell specification.
     
@@ -2758,6 +2765,7 @@ def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_pr
         actions_set: The Actions class to use (optional, needed for ControlButton)
         stumble_probability: Default stumble probability for UnsteadyGround (0.0 to 1.0)
         solidify_probability: Default solidify probability for MagicWall (0.0 to 1.0)
+        trample_probability: Default trample probability for Bush (0.0 to 1.0)
         
     Returns:
         WorldObj or None for empty cells
@@ -2774,7 +2782,8 @@ def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_pr
     elif obj_type == 'rock':
         return Rock(objects_set)
     elif obj_type == 'bush':
-        return Bush(objects_set, trampled=params.get('trampled', False))
+        return Bush(objects_set, trampled=params.get('trampled', False),
+                    trample_probability=params.get('trample_probability', trample_probability))
     elif obj_type == 'lava':
         return Lava(objects_set)
     elif obj_type == 'switch':
@@ -2877,7 +2886,8 @@ class MultiGridEnv(WorldModel):
             config_file=None,
             config=None,
             stumble_probability=0.5,
-            solidify_probability=0.1
+            solidify_probability=0.1,
+            trample_probability=1.0
     ):
         """
         Initialize a MultiGridEnv.
@@ -2911,6 +2921,7 @@ class MultiGridEnv(WorldModel):
                    If both config and config_file are provided, config_file takes precedence.
             stumble_probability: Default probability of stumbling on UnsteadyGround (0.0 to 1.0)
             solidify_probability: Default probability of MagicWall solidifying on failed entry (0.0 to 1.0)
+            trample_probability: Default probability that a robot successfully tramples a Bush (0.0 to 1.0)
         """
         # Load config from config file or dict if provided
         if config_file is not None:
@@ -2950,6 +2961,8 @@ class MultiGridEnv(WorldModel):
                 stumble_probability = config['stumble_probability']
             if solidify_probability == 0.1 and 'solidify_probability' in config:  # default: 0.1
                 solidify_probability = config['solidify_probability']
+            if trample_probability == 1.0 and 'trample_probability' in config:  # default: 1.0
+                trample_probability = config['trample_probability']
             # Handle action_class from config
             if actions_set is Actions and 'action_class' in config:
                 action_class_name = config['action_class']
@@ -2984,6 +2997,9 @@ class MultiGridEnv(WorldModel):
         
         # Store solidify_probability for use by MagicWall objects
         self.solidify_probability = solidify_probability
+        
+        # Store trample_probability as the default for Bush objects
+        self.trample_probability = trample_probability
         
         # Initialize RNG early so we can use it for random orientations
         # This is done before reset() to allow random orientations to be drawn in __init__
@@ -3449,7 +3465,8 @@ class MultiGridEnv(WorldModel):
                 if cell_spec is not None and cell_spec[0] != 'agent':
                     obj = create_object_from_spec(cell_spec, self.objects, self.actions, 
                                                   stumble_probability=self.stumble_probability,
-                                                  solidify_probability=self.solidify_probability)
+                                                  solidify_probability=self.solidify_probability,
+                                                  trample_probability=self.trample_probability)
                     if obj is not None:
                         self.grid.set(x, y, obj)
         
@@ -4218,7 +4235,7 @@ class MultiGridEnv(WorldModel):
     
     def _categorize_agents(self, actions, active_agents=None):
         """
-        Helper function to categorize agents into normal, unsteady-forward, and magic-wall-entry groups.
+        Helper function to categorize agents into normal, unsteady-forward, magic-wall-entry, and bush-trampling groups.
         This logic is shared between step() and transition_probabilities().
         
         **IMPORTANT NOTE FOR DEVELOPERS:**
@@ -4241,17 +4258,19 @@ class MultiGridEnv(WorldModel):
         Examples of stochastic elements that follow this pattern:
         - Unsteady ground: agent stumbles with probability, creating 3 outcomes (forward, left+forward, right+forward)
         - Magic walls: agent enters with probability, creating 2 outcomes (succeed, fail)
+        - Bush trampling: trampling succeeds with probability, creating 2 outcomes (succeed, fail)
         
         Args:
             actions: List of action indices, one per agent
             active_agents: List of active agent indices (if None, determines from agent states)
             
         Returns:
-            tuple: (normal_agents, unsteady_forward_agents, magic_wall_agents)
+            tuple: (normal_agents, unsteady_forward_agents, magic_wall_agents, bush_agents)
         """
         normal_agents = []
         unsteady_forward_agents = []
         magic_wall_agents = []
+        bush_agents = []
         
         # Determine active agents if not provided
         if active_agents is None:
@@ -4278,6 +4297,16 @@ class MultiGridEnv(WorldModel):
                     if fwd_cell.magic_side == 4 or approach_dir == fwd_cell.magic_side:
                         magic_wall_agents.append(i)
                         continue
+            
+            # Check if agent is attempting probabilistic bush trampling
+            if actions[i] == self.actions.forward:
+                fwd_pos = self.agents[i].front_pos
+                fwd_cell = self.grid.get(*fwd_pos)
+                if (fwd_cell is not None and fwd_cell.type == 'bush' and
+                        fwd_cell.can_be_trampled_by(self.agents[i]) and
+                        fwd_cell.trample_probability < 1.0):
+                    bush_agents.append(i)
+                    continue
                 
             # Check if agent is on unsteady ground and attempting forward
             if (actions[i] == self.actions.forward and 
@@ -4286,7 +4315,7 @@ class MultiGridEnv(WorldModel):
             else:
                 normal_agents.append(i)
         
-        return normal_agents, unsteady_forward_agents, magic_wall_agents
+        return normal_agents, unsteady_forward_agents, magic_wall_agents, bush_agents
 
     def step(self, actions):
         # Clear visual feedback from previous step
@@ -5366,9 +5395,10 @@ class MultiGridEnv(WorldModel):
         
         # OPTIMIZATION 1: If ≤1 agents active, check if transition is deterministic
         # (only deterministic if the agent is NOT on unsteady ground attempting forward
-        # and NOT attempting to enter a magic wall)
+        # and NOT attempting to enter a magic wall, and NOT attempting probabilistic bush trampling)
         if len(active_agents) <= 1:
-            # Check if the single agent is on unsteady ground or attempting magic wall entry
+            # Check if the single agent is on unsteady ground, attempting magic wall entry,
+            # or attempting probabilistic bush trampling
             is_stochastic = False
             if len(active_agents) == 1:
                 agent_idx = active_agents[0]
@@ -5383,6 +5413,14 @@ class MultiGridEnv(WorldModel):
                             approach_dir = (self.agents[agent_idx].dir + 2) % 4
                             if approach_dir == fwd_cell.magic_side:
                                 is_stochastic = True
+                    if not is_stochastic:
+                        # Check if agent is trampling a probabilistic bush
+                        fwd_pos = self.agents[agent_idx].front_pos
+                        fwd_cell = self.grid.get(*fwd_pos)
+                        if (fwd_cell is not None and fwd_cell.type == 'bush' and
+                                fwd_cell.can_be_trampled_by(self.agents[agent_idx]) and
+                                fwd_cell.trample_probability < 1.0):
+                            is_stochastic = True
             
             if not is_stochastic:
                 # Only one or zero agents acting and not stochastic - order doesn't matter
@@ -5396,27 +5434,36 @@ class MultiGridEnv(WorldModel):
             for i in active_agents
         )
         if n_non_rotations < 2:
-            # Check if any agents are on unsteady ground or attempting magic wall entry
-            has_stochastic = any(
-                actions[i] == self.actions.forward and (
-                    self.agents[i].on_unsteady_ground or
-                    (self.agents[i].can_enter_magic_walls and
-                     self.grid.get(*self.agents[i].front_pos) is not None and
-                     self.grid.get(*self.agents[i].front_pos).type == 'magicwall' and
-                     (self.agents[i].dir + 2) % 4 == self.grid.get(*self.agents[i].front_pos).magic_side)
-                )
-                for i in active_agents
-            )
+            # Check if any agents are on unsteady ground, attempting magic wall entry,
+            # or attempting probabilistic bush trampling
+            def _is_stochastic_forward(i):
+                if actions[i] != self.actions.forward:
+                    return False
+                if self.agents[i].on_unsteady_ground:
+                    return True
+                fwd_cell = self.grid.get(*self.agents[i].front_pos)
+                if fwd_cell is None:
+                    return False
+                if (self.agents[i].can_enter_magic_walls and
+                        fwd_cell.type == 'magicwall' and
+                        (self.agents[i].dir + 2) % 4 == fwd_cell.magic_side):
+                    return True
+                if (fwd_cell.type == 'bush' and
+                        fwd_cell.can_be_trampled_by(self.agents[i]) and
+                        fwd_cell.trample_probability < 1.0):
+                    return True
+                return False
+            has_stochastic = any(_is_stochastic_forward(i) for i in active_agents)
             if not has_stochastic:
                 # Rotations are commutative and no stochastic agents - result is deterministic
                 successor_state = self._compute_successor_state(state, actions, tuple(range(num_agents)))
                 return [(1.0, successor_state)]
         
         # Use helper to categorize agents
-        normal_active_agents, unsteady_forward_agents, magic_wall_agents = self._categorize_agents(actions, active_agents)
+        normal_active_agents, unsteady_forward_agents, magic_wall_agents, bush_agents = self._categorize_agents(actions, active_agents)
         
         # OPTIMIZATION 3: Partition ONLY normal (non-stochastic) agents into conflict blocks
-        # Unsteady and magic wall agents are excluded because they're handled separately
+        # Unsteady, magic wall, and bush agents are excluded because they're handled separately
         # This is MORE efficient than permuting all active agents
         # Instead of k! permutations, we compute the Cartesian product of conflict blocks
         conflict_blocks = self._identify_conflict_blocks(actions, normal_active_agents)
@@ -5424,14 +5471,15 @@ class MultiGridEnv(WorldModel):
         # If no conflicts and no stochastic agents, result is deterministic
         if (all(len(block) == 1 for block in conflict_blocks) and 
             len(unsteady_forward_agents) == 0 and 
-            len(magic_wall_agents) == 0):
+            len(magic_wall_agents) == 0 and
+            len(bush_agents) == 0):
             successor_state = self._compute_successor_state(state, actions, tuple(range(num_agents)))
             return [(1.0, successor_state)]
         
-        # OPTIMIZATION 4: Compute outcomes via Cartesian product of conflict blocks, unsteady blocks, and magic wall blocks
+        # OPTIMIZATION 4: Compute outcomes via Cartesian product of conflict blocks, unsteady blocks, magic wall blocks, and bush blocks
         # Each outcome has probability = 1 / product(block_sizes)
         
-        # Build list of all blocks (conflict blocks + unsteady agent blocks + magic wall blocks)
+        # Build list of all blocks (conflict blocks + unsteady agent blocks + magic wall blocks + bush blocks)
         all_blocks = []
         
         # Add conflict blocks
@@ -5484,15 +5532,28 @@ class MultiGridEnv(WorldModel):
             ]
             all_blocks.append(('magicwall', agent_idx, outcomes))
         
+        # Add bush trampling blocks (one per bush-trampling agent)
+        # Each block has 2 outcomes: succeed (bush trampled, agent moves in) or fail (agent stays)
+        for agent_idx in bush_agents:
+            fwd_pos = self.agents[agent_idx].front_pos
+            fwd_cell = self.grid.get(*fwd_pos)
+            trample_prob = fwd_cell.trample_probability if fwd_cell else 1.0
+            outcomes = [
+                (trample_prob, 'succeed'),
+                (1.0 - trample_prob, 'fail'),
+            ]
+            all_blocks.append(('bush', agent_idx, outcomes))
+        
         # Generate all possible outcome combinations
         # For conflict blocks: winner index (which agent wins) - uniform probability
         # For unsteady blocks: outcome index into (probability, outcome) pairs
         # For magic wall blocks: outcome index into (probability, outcome) pairs
+        # For bush blocks: outcome index into (probability, outcome) pairs
         
         def get_block_size(block):
             if block[0] == 'conflict':
                 return len(block[1])
-            elif block[0] in ['unsteady', 'magicwall']:
+            elif block[0] in ['unsteady', 'magicwall', 'bush']:
                 return len(block[2])  # Number of (probability, outcome) pairs
             else:
                 return 1
@@ -5507,7 +5568,7 @@ class MultiGridEnv(WorldModel):
                 if block[0] == 'conflict':
                     # Uniform random winner
                     outcome_indices.append(np.random.randint(size))
-                elif block[0] in ['unsteady', 'magicwall']:
+                elif block[0] in ['unsteady', 'magicwall', 'bush']:
                     # Sample according to outcome probabilities
                     probs = [block[2][j][0] for j in range(size)]
                     outcome_indices.append(np.random.choice(size, p=probs))
@@ -5540,10 +5601,18 @@ class MultiGridEnv(WorldModel):
                     _, outcome_type = block[2][outcome_indices[i]]
                     magic_wall_outcomes[agent_idx] = outcome_type
             
+            # Process bush blocks to determine outcomes
+            bush_outcomes = {}
+            for i, block in enumerate(all_blocks):
+                if block[0] == 'bush':
+                    agent_idx = block[1]
+                    _, outcome_type = block[2][outcome_indices[i]]
+                    bush_outcomes[agent_idx] = outcome_type
+            
             # Compute the single successor state
             succ_state = self._compute_successor_state_with_unsteady(
                 state, modified_actions, num_agents, active_agents,
-                conflict_blocks, conflict_winners, magic_wall_outcomes
+                conflict_blocks, conflict_winners, magic_wall_outcomes, bush_outcomes
             )
             return [(1.0, succ_state)]
         
@@ -5565,7 +5634,7 @@ class MultiGridEnv(WorldModel):
                 if block[0] == 'conflict':
                     # Uniform probability over conflict block members
                     outcome_probability *= 1.0 / len(block[1])
-                elif block[0] in ['unsteady', 'magicwall']:
+                elif block[0] in ['unsteady', 'magicwall', 'bush']:
                     # Use the probability from the (probability, outcome) pair
                     prob, _ = block[2][outcome_idx]
                     outcome_probability *= prob
@@ -5600,10 +5669,19 @@ class MultiGridEnv(WorldModel):
                     _, outcome_type = block[2][outcome_idx]  # Extract outcome from (probability, outcome) pair
                     magic_wall_outcomes[agent_idx] = outcome_type
             
+            # Process bush blocks to determine outcomes
+            bush_outcomes = {}
+            for i, block in enumerate(all_blocks):
+                if block[0] == 'bush':
+                    agent_idx = block[1]
+                    outcome_idx = outcome_indices[i]
+                    _, outcome_type = block[2][outcome_idx]  # Extract outcome from (probability, outcome) pair
+                    bush_outcomes[agent_idx] = outcome_type
+            
             # Compute the successor state for this outcome
             succ_state = self._compute_successor_state_with_unsteady(
                 state, modified_actions, num_agents, active_agents, 
-                conflict_blocks, conflict_winners, magic_wall_outcomes
+                conflict_blocks, conflict_winners, magic_wall_outcomes, bush_outcomes
             )
             
             # Aggregate probabilities for identical successor states
@@ -5903,14 +5981,15 @@ class MultiGridEnv(WorldModel):
     
     def _compute_successor_state_with_unsteady(self, state, modified_actions, num_agents, 
                                                active_agents, conflict_blocks, conflict_winners, 
-                                               magic_wall_outcomes=None):
+                                               magic_wall_outcomes=None, bush_outcomes=None):
         """
-        Compute successor state with unsteady ground and magic wall stochasticity.
+        Compute successor state with unsteady ground, magic wall, and bush trampling stochasticity.
         
         This handles the special processing order required for stochastic elements:
         1. Process normal agents first (with conflict resolution)
         2. Process unsteady-forward agents after (with stumbling outcomes)
-        3. Process magic wall entry attempts last (with probabilistic outcomes)
+        3. Process magic wall entry attempts (with probabilistic outcomes)
+        4. Process bush trampling attempts last (with probabilistic outcomes)
         
         Args:
             state: Current state tuple
@@ -5919,7 +5998,8 @@ class MultiGridEnv(WorldModel):
             active_agents: List of active agent indices
             conflict_blocks: List of conflict blocks
             conflict_winners: List of (block_idx, winner_agent_idx) tuples
-            magic_wall_outcomes: Optional dict mapping agent_idx -> outcome_type ('succeed' or 'fail')
+            magic_wall_outcomes: Optional dict mapping agent_idx -> outcome_type ('succeed', 'fail', or 'solidify')
+            bush_outcomes: Optional dict mapping agent_idx -> outcome_type ('succeed' or 'fail')
             
         Returns:
             tuple: The successor state
@@ -5937,11 +6017,12 @@ class MultiGridEnv(WorldModel):
             if agent.pos is not None and not agent.terminated:
                 self._initial_agent_positions.add(tuple(agent.pos))
         
-        # Separate agents into normal, unsteady-forward, and magic-wall
+        # Separate agents into normal, unsteady-forward, magic-wall, and bush-trampling
         normal_agents = []
         unsteady_forward_agents_list = []
         unsteady_outcomes_dict = {}  # agent_idx -> outcome_type
         magic_wall_agents_list = []
+        bush_agents_list = []
         
         for i in range(num_agents):
             if (self.agents[i].terminated or 
@@ -5960,6 +6041,9 @@ class MultiGridEnv(WorldModel):
                 # Check if this is a magic wall agent
                 if magic_wall_outcomes and i in magic_wall_outcomes:
                     magic_wall_agents_list.append(i)
+                # Check if this is a bush trampling agent
+                elif bush_outcomes and i in bush_outcomes:
+                    bush_agents_list.append(i)
                 else:
                     normal_agents.append(i)
         
@@ -6020,6 +6104,20 @@ class MultiGridEnv(WorldModel):
                     if fwd_cell and fwd_cell.type == 'magicwall':
                         fwd_cell.active = False
                 # If outcome is 'fail', agent stays in place and wall stays magic (no action)
+        
+        # Process bush trampling agents (deterministic based on pre-sampled outcome)
+        if bush_agents_list:
+            for i in bush_agents_list:
+                outcome = bush_outcomes[i]
+                if outcome == 'succeed':
+                    # Trampling succeeds: remove bush and move agent into the cell
+                    fwd_pos = self.agents[i].front_pos
+                    fwd_cell = self.grid.get(*fwd_pos)
+                    if fwd_cell is not None and fwd_cell.type == 'bush':
+                        fwd_cell.trampled = True
+                        self.grid.set(*fwd_pos, None)
+                        self._move_agent_to_cell(i, fwd_pos, None)
+                # If outcome is 'fail', agent stays in place and bush remains (no action)
         
         # Check if max steps reached
         if self.step_count >= self.max_steps:

--- a/vendor/multigrid/gym_multigrid/multigrid.py
+++ b/vendor/multigrid/gym_multigrid/multigrid.py
@@ -316,7 +316,7 @@ class ConfigGoalGenerator:
         # Find all walkable cells (not containing immovable non-overlappable objects)
         # Agents can never stand on these cell types:
         non_walkable_types = {
-            'wall', 'lava', 'magicwall',
+            'wall', 'lava', 'magicwall', 'bush',
             'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton',
         }
         uncovered = []
@@ -493,7 +493,7 @@ class ConfigGoalSampler:
         # Find all walkable cells (not containing immovable non-overlappable objects)
         # Agents can never stand on these cell types:
         non_walkable_types = {
-            'wall', 'lava', 'magicwall',
+            'wall', 'lava', 'magicwall', 'bush',
             'killbutton', 'pauseswitch', 'disablingswitch', 'controlbutton',
         }
         uncovered = []
@@ -650,7 +650,8 @@ class World:
         'killbutton': 17,
         'pauseswitch': 18,
         'disablingswitch': 19,
-        'controlbutton': 20
+        'controlbutton': 20,
+        'bush': 21,
     }
     IDX_TO_OBJECT = dict(zip(OBJECT_TO_IDX.values(), OBJECT_TO_IDX.keys()))
 
@@ -1838,6 +1839,62 @@ class Rock(WorldObj):
         fill_coords(img, point_in_circle(0.65, 0.55, 0.10), darker_grey)
 
 
+class Bush(WorldObj):
+    """
+    Dense bush that blocks humans until a robot tramples it.
+
+    A bush is mutable but immobile. Before trampling it is non-overlappable.
+    When an authorized robot-like agent moves forward into it, the bush is
+    marked trampled and removed from the grid, making the cell empty for all
+    agents afterwards.
+    """
+
+    def __init__(self, world, trampled=False):
+        super(Bush, self).__init__(world, 'bush', 'green')
+        self.trampled = trampled
+
+    def can_overlap(self):
+        return False
+
+    def can_pickup(self):
+        return False
+
+    def can_be_trampled_by(self, agent):
+        return (
+            getattr(agent, 'can_push_rocks', False) or
+            getattr(agent, 'can_enter_magic_walls', False) or
+            getattr(agent, 'color', None) == 'grey'
+        )
+
+    def encode(self, world, current_agent=False):
+        if world.encode_dim == 3:
+            return (
+                world.OBJECT_TO_IDX[self.type],
+                world.COLOR_TO_IDX[self.color],
+                1 if self.trampled else 0,
+            )
+        return (
+            world.OBJECT_TO_IDX[self.type],
+            world.COLOR_TO_IDX[self.color],
+            1 if self.trampled else 0,
+            0,
+            0,
+            0,
+        )
+
+    def render(self, img):
+        if self.trampled:
+            return
+
+        c = COLORS[self.color]
+        dark = np.array([20, 90, 30])
+        light = np.array([90, 180, 75])
+        fill_coords(img, point_in_circle(0.35, 0.48, 0.28), c)
+        fill_coords(img, point_in_circle(0.58, 0.42, 0.30), light)
+        fill_coords(img, point_in_circle(0.56, 0.62, 0.26), c)
+        fill_coords(img, point_in_circle(0.42, 0.58, 0.22), dark)
+
+
 class Agent(WorldObj):
     def __init__(self, world, index=0, view_size=7, can_enter_magic_walls=False, can_push_rocks=False):
         super(Agent, self).__init__(world, 'agent', world.IDX_TO_COLOR[index])
@@ -2493,6 +2550,7 @@ def parse_map_string(map_spec, objects_set=World):
     - Wc : wall of color c
     - Bl : block
     - Ro : rock  
+    - Bu : bush (robot-tramplable obstacle)
     - Lc : locked door of color c
     - Cc : closed door of color c
     - Oc : open door of color c
@@ -2618,6 +2676,8 @@ def _parse_cell(cell_str, objects_set):
         return ('block', {})
     elif full_cell_code == 'Ro':
         return ('rock', {})
+    elif full_cell_code == 'Bu':
+        return ('bush', {})
     elif full_cell_code == 'La':
         return ('lava', {})
     elif full_cell_code == 'Sw':
@@ -2713,6 +2773,8 @@ def create_object_from_spec(cell_spec, objects_set, actions_set=None, stumble_pr
         return Block(objects_set)
     elif obj_type == 'rock':
         return Rock(objects_set)
+    elif obj_type == 'bush':
+        return Bush(objects_set, trampled=params.get('trampled', False))
     elif obj_type == 'lava':
         return Lava(objects_set)
     elif obj_type == 'switch':
@@ -3173,7 +3235,7 @@ class MultiGridEnv(WorldModel):
         # Track cells where stumbling occurred in the current step (for visual feedback)
         self.stumbled_cells = set()
         
-        # Build cache of mobile objects (blocks, rocks) and mutable objects (doors, boxes, magic walls)
+        # Build cache of mobile objects (blocks, rocks) and mutable objects (doors, boxes, magic walls, bushes)
         # This avoids full grid scans in get_state()
         self._build_object_cache()
         
@@ -3194,7 +3256,7 @@ class MultiGridEnv(WorldModel):
         Build cache of mobile and mutable objects to avoid full grid scans in get_state().
         
         Mobile objects: blocks and rocks (can be pushed)
-        Mutable objects: doors, boxes, magic walls, killbuttons, pauseswitches, controlbuttons (have mutable state)
+        Mutable objects: doors, boxes, magic walls, bushes, killbuttons, pauseswitches, controlbuttons (have mutable state)
         
         This cache stores references to the objects themselves, not their positions.
         Positions are read from the grid when get_state() is called.
@@ -3214,8 +3276,8 @@ class MultiGridEnv(WorldModel):
                 if obj_type in ('block', 'rock'):
                     self._mobile_objects.append(((i, j), cell))
                 
-                # Mutable objects: doors, boxes, magic walls, killbuttons, pauseswitches, controlbuttons
-                elif obj_type in ('door', 'box', 'magicwall', 'killbutton', 'pauseswitch', 'controlbutton'):
+                # Mutable objects: doors, boxes, magic walls, bushes, killbuttons, pauseswitches, controlbuttons
+                elif obj_type in ('door', 'box', 'magicwall', 'bush', 'killbutton', 'pauseswitch', 'controlbutton'):
                     self._mutable_objects.append(((i, j), cell))
         
         # Sort mobile objects by initial position for deterministic ordering
@@ -3315,6 +3377,7 @@ class MultiGridEnv(WorldModel):
             'box': 'B',
             'goal': 'G',
             'lava': 'V',
+            'bush': 'U',
         }
 
         # Short string for opened door
@@ -3532,6 +3595,9 @@ class MultiGridEnv(WorldModel):
                 return False
             can_push, _, _ = self._can_push_objects(agent, np.array([fwd_x, fwd_y]))
             return can_push
+
+        if fwd_cell.type == 'bush':
+            return fwd_cell.can_be_trampled_by(agent)
         
         # Check for magic walls
         if fwd_cell.type == 'magicwall' and fwd_cell.active:
@@ -3657,6 +3723,16 @@ class MultiGridEnv(WorldModel):
         
         # Set new position
         self.grid.set(*self.agents[agent_idx].pos, self.agents[agent_idx])
+
+    def _trample_bush(self, agent_idx, target_pos, bush):
+        """Trample a bush and move the agent into its now-empty cell."""
+        if not bush.can_be_trampled_by(self.agents[agent_idx]):
+            return False
+
+        bush.trampled = True
+        self.grid.set(*target_pos, None)
+        self._move_agent_to_cell(agent_idx, target_pos, None)
+        return True
     
     def _handle_switch(self, i, rewards, fwd_pos, fwd_cell):
         pass
@@ -3909,6 +3985,8 @@ class MultiGridEnv(WorldModel):
                     done = True
                     self._reward(agent_idx, rewards, 1)
                     self._move_agent_to_cell(agent_idx, fwd_pos, fwd_cell)
+                elif fwd_cell.type == 'bush':
+                    self._trample_bush(agent_idx, fwd_pos, fwd_cell)
                 elif fwd_cell.type == 'switch':
                     self._handle_switch(agent_idx, rewards, fwd_pos, fwd_cell)
                     self._move_agent_to_cell(agent_idx, fwd_pos, fwd_cell)
@@ -4068,6 +4146,8 @@ class MultiGridEnv(WorldModel):
                         done = True
                         self._reward(i, rewards, 1)
                         can_move = True
+                    elif fwd_cell.type == 'bush':
+                        can_move = self._trample_bush(i, fwd_pos, fwd_cell)
                     elif fwd_cell.type == 'switch':
                         self._handle_switch(i, rewards, fwd_pos, fwd_cell)
                         can_move = True
@@ -4080,7 +4160,7 @@ class MultiGridEnv(WorldModel):
                 else:
                     can_move = False
             
-            if can_move:
+            if can_move and not (fwd_cell is not None and fwd_cell.type == 'bush'):
                 self._move_agent_to_cell(i, fwd_pos, fwd_cell)
                 self._handle_special_moves(i, rewards, fwd_pos, fwd_cell)
         
@@ -4790,7 +4870,7 @@ class MultiGridEnv(WorldModel):
         - step_count: int
         - agent_states: tuple of (pos_x, pos_y, dir, terminated, started, paused, carrying_type, carrying_color, forced_next_action)
         - mobile_objects: tuple of (obj_type, pos_x, pos_y) for blocks/rocks
-        - mutable_objects: tuple of (obj_type, x, y, mutable_state...) for doors/boxes/magic walls
+        - mutable_objects: tuple of (obj_type, x, y, mutable_state...) for doors/boxes/magic walls/bushes
         
         Note: on_unsteady_ground is NOT stored in the state - it is derived from the
         agent's position and the terrain_grid when set_state() is called.
@@ -4828,7 +4908,7 @@ class MultiGridEnv(WorldModel):
             for j in range(self.grid.height):
                 for i in range(self.grid.width):
                     cell = self.grid.get(i, j)
-                    if cell is not None and cell.type in ('block', 'rock', 'door', 'box', 'magicwall', 'killbutton', 'pauseswitch', 'controlbutton'):
+                    if cell is not None and cell.type in ('block', 'rock', 'door', 'box', 'magicwall', 'bush', 'killbutton', 'pauseswitch', 'controlbutton'):
                         has_trackable = True
                         break
                 if has_trackable:
@@ -4875,6 +4955,12 @@ class MultiGridEnv(WorldModel):
                     'magicwall',
                     x, y,
                     obj.active,
+                ))
+            elif obj.type == 'bush':
+                mutable_objects.append((
+                    'bush',
+                    x, y,
+                    obj.trampled,
                 ))
             elif obj.type == 'killbutton':
                 mutable_objects.append((
@@ -5081,7 +5167,7 @@ class MultiGridEnv(WorldModel):
                 obj.cur_pos = np.array([x, y])
                 self.grid.set(x, y, obj)
         
-        # Restore mutable objects (doors, boxes, magic walls, killbuttons, pauseswitches)
+        # Restore mutable objects (doors, boxes, magic walls, bushes, killbuttons, pauseswitches)
         for mutable_obj in mutable_objects:
             obj_type = mutable_obj[0]
             x, y = mutable_obj[1], mutable_obj[2]
@@ -5111,6 +5197,26 @@ class MultiGridEnv(WorldModel):
                 active = mutable_obj[3]
                 if cell is not None and cell.type == 'magicwall':
                     cell.active = active
+
+            elif obj_type == 'bush':
+                trampled = mutable_obj[3]
+                cached_bush = None
+                if hasattr(self, '_mutable_objects'):
+                    for (obj_x, obj_y), obj in self._mutable_objects:
+                        if obj_x == x and obj_y == y and obj.type == 'bush':
+                            cached_bush = obj
+                            break
+
+                if cached_bush is not None:
+                    cached_bush.trampled = trampled
+                    terrain_cell = self.terrain_grid.get(x, y)
+                    if trampled:
+                        if cell is not None and cell is cached_bush:
+                            self.grid.set(x, y, None)
+                        if terrain_cell is cached_bush:
+                            self.terrain_grid.set(x, y, None)
+                    elif cell is None:
+                        self.grid.set(x, y, cached_bush)
             
             elif obj_type == 'killbutton':
                 enabled = mutable_obj[3]


### PR DESCRIPTION
Added Bush / map code Bu in multigrid.py.

Fresh bushes block humans. Robot-like agents can trample bushes by moving forward into them. Once trampled, the bush is removed from the grid and humans can pass through that cell.
